### PR TITLE
feat: implement issue #39 git history keyword search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## 0.4.0
+### Added
+- **Keyword Search in Git History**: Optional scanning for configured keywords in commit messages and historical file content changes ([#39](https://github.com/nikolareljin/leak-lock/issues/39))
+  - New settings to enable/disable keyword history scanning
+  - Separate toggles for commit-message scanning and file-history scanning
+  - Configurable keyword list and per-keyword match cap
+  - Default keyword profile targets agent-attribution terms and sensitive credential wording
+  - Keyword matches are surfaced in scan results with git commit metadata
+
 ## 0.3.0
 ### Added
 - **Scan Results Export**: Export scan findings as JSON and print/save the current results view as PDF ([#37](https://github.com/nikolareljin/leak-lock/issues/37))

--- a/README.md
+++ b/README.md
@@ -102,8 +102,9 @@ code --install-extension leak-lock-0.0.1.vsix
   - `leakLock.gitHistoryKeywordSearch.maxMatchesPerKeyword`
 
 Default keyword profile (designed for attribution-policy and secret hygiene):
-- Agent/AI attribution terms: `ai`, `agent`, `assistant`, `claude`, `codex`, `copilot`, `gemini`, `gpt`, `chatgpt`, `openai`, `anthropic`, `aider`, `cursor`, `windsurf`, `meldbot`, `openclaw`, `nanoclaw`
+- Agent/AI attribution terms: `agent`, `assistant`, `claude`, `codex`, `copilot`, `gemini`, `gpt`, `chatgpt`, `openai`, `anthropic`, `aider`, `cursor`, `windsurf`, `meldbot`, `openclaw`, `nanoclaw`
 - Sensitive terms: `password`, `token`, `api_key`, `secret`
+Note: In file-history mode, very short keywords are skipped to reduce noise and improve performance.
 
 Example use case:
 - Detect commit messages that mention coding agents.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Secure your code repositories by detecting and removing sensitive information from git history**
 
-[![Version](https://img.shields.io/badge/version-0.3.0-blue.svg)](package.json)
+[![Version](https://img.shields.io/badge/version-0.4.0-blue.svg)](package.json)
 [![VS Code](https://img.shields.io/badge/VS%20Code-1.96.0+-brightgreen.svg)](https://code.visualstudio.com/)
 
 [📖 Documentation](#documentation) • [🚀 Quick Start](#quick-start) • [📸 Screenshots](#screenshots) • [🛠️ Development](#development)
@@ -91,6 +91,23 @@ code --install-extension leak-lock-0.0.1.vsix
 
 
 ---
+
+### 6.1 Optional Keyword Search in Git History (New)
+- Open VS Code settings for Leak Lock.
+- Enable `leakLock.gitHistoryKeywordSearch.enabled`.
+- Configure keywords in `leakLock.gitHistoryKeywordSearch.keywords`.
+- Optionally tune:
+  - `leakLock.gitHistoryKeywordSearch.searchCommitMessages`
+  - `leakLock.gitHistoryKeywordSearch.searchFileHistory`
+  - `leakLock.gitHistoryKeywordSearch.maxMatchesPerKeyword`
+
+Default keyword profile (designed for attribution-policy and secret hygiene):
+- Agent/AI attribution terms: `ai`, `agent`, `assistant`, `claude`, `codex`, `copilot`, `gemini`, `gpt`, `chatgpt`, `openai`, `anthropic`, `aider`, `cursor`, `windsurf`, `meldbot`, `openclaw`, `nanoclaw`
+- Sensitive terms: `password`, `token`, `api_key`, `secret`
+
+Example use case:
+- Detect commit messages that mention coding agents.
+- Detect potentially sensitive terms in historical file changes.
 
 ### 7. Remove Unwanted Files (New)
 - Open from sidebar: click "🗑️ Remove files"

--- a/leakLockPanel.js
+++ b/leakLockPanel.js
@@ -1873,11 +1873,13 @@ class LeakLockPanel {
             ? 'Remote refs may be outdated (older than 15 minutes). Fetch to ensure cleanup considers latest branches and tags.'
             : 'Remotes fetched recently; cleanup reflects current branches and tags.';
 
-        const branchDataMap = {}; // index → branches array, populated during map
+        const branchDataMap = {}; // index -> branches array, populated during map
         const resultsRows = this._scanResults.map((result, index) => {
             const isDependency = result.isDependency;
             const isGitHistory = result.isGitHistory;
             const isUntracked = result.isUntracked;
+            const includeInCleanup = result.includeInCleanup !== false;
+            const cleanupDisabled = isDependency || !includeInCleanup;
 
             // Choose appropriate icon and styling
             let icon = '📄';
@@ -1901,6 +1903,7 @@ class LeakLockPanel {
                     : isDependency
                         ? ' (dependency directory)'
                         : '';
+            const cleanupNote = includeInCleanup ? '' : ' (keyword history reference only)';
 
             // Build git info display for commit details
             const shortHash = result.commitHash ? result.commitHash.substring(0, 7) : null;
@@ -1978,8 +1981,8 @@ class LeakLockPanel {
 
             return `
                 <tr data-finding-index="${index}" data-file="${escapeHtml(result.file)}" data-line="${result.line}" style="border-left: 3px solid ${severityColors[result.severity] || '#666'}; ${rowStyle}">
-                    <td><input type="checkbox" class="secret-checkbox checkbox" ${isDependency ? 'disabled' : 'checked'}></td>
-                    <td title="${escapeHtml(result.file)}${contextNote}">
+                    <td><input type="checkbox" class="secret-checkbox checkbox" ${cleanupDisabled ? 'disabled' : 'checked'}></td>
+                    <td title="${escapeHtml(result.file)}${contextNote}${cleanupNote}">
                         <span class="file-link ${isGitHistory ? 'disabled' : 'clickable'}" data-file="${escapeHtml(result.file)}" data-line="${result.line}" style="font-family: monospace; font-size: 0.9em; color: var(--vscode-textLink-foreground); ${isGitHistory ? 'cursor: default;' : 'cursor: pointer; text-decoration: underline;'}" title="${iconTooltip}">
                             ${icon} ${escapeHtml(result.file)}
                         </span>
@@ -1998,7 +2001,7 @@ class LeakLockPanel {
                         </span>
                     </td>
                     <td>
-                        <input type="text" class="replacement-input" value="*****" placeholder="Replacement value" ${isDependency ? 'disabled' : ''}>
+                        <input type="text" class="replacement-input" value="*****" placeholder="Replacement value" ${cleanupDisabled ? 'disabled' : ''}>
                     </td>
                     <td title="${escapeHtml(gitInfoTooltip)}" style="font-size: 0.85em; line-height: 1.4; overflow: visible; white-space: normal; word-break: break-word;">
                         ${gitInfoHtml}
@@ -2012,6 +2015,7 @@ class LeakLockPanel {
                                 ${escapeHtml(result.description)}
                                 ${isDependency ? ' <span style="color: var(--vscode-descriptionForeground); font-size: 0.8em;">(in dependency)</span>' : ''}
                                 ${isUntracked ? ' <span style="color: var(--vscode-gitDecoration-addedResourceForeground); font-size: 0.8em;">(not committed)</span>' : ''}
+                                ${!includeInCleanup ? ' <span style="color: var(--vscode-descriptionForeground); font-size: 0.8em;">(excluded from cleanup)</span>' : ''}
                             </span>
                         </div>
                     </td>
@@ -2290,12 +2294,31 @@ class LeakLockPanel {
             1,
             keyword,
             description,
-            'git_history_keyword'
+            'git_history_keyword',
+            null,
+            { forceGitHistory: true, includeInCleanup: false }
         );
-        result.isGitHistory = true;
+        result.isKeywordHistory = true;
         result.commitHash = commitHash || null;
         result.commitDate = commitDate || null;
         return result;
+    }
+
+    _escapeRegExp(value) {
+        return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    }
+
+    _keywordMatchesText(text, keyword) {
+        const normalizedText = String(text || '');
+        const keywordLower = String(keyword || '').toLowerCase();
+        if (!keywordLower) {
+            return false;
+        }
+        if (keywordLower.length <= 3) {
+            const boundaryRegex = new RegExp(`\\b${this._escapeRegExp(keywordLower)}\\b`, 'i');
+            return boundaryRegex.test(normalizedText);
+        }
+        return normalizedText.toLowerCase().includes(keywordLower);
     }
 
     async _scanGitHistoryForKeywords(scanPath) {
@@ -2309,14 +2332,20 @@ class LeakLockPanel {
         const execFileAsync = util.promisify(execFile);
         const findings = [];
         const seen = new Set();
+        const totalSearchModes = (keywordConfig.searchCommitMessages ? 1 : 0) + (keywordConfig.searchFileHistory ? 1 : 0);
+        const maxTotalFindings = Math.max(50, Math.min(2000, keywordConfig.keywords.length * keywordConfig.maxMatchesPerKeyword * Math.max(1, totalSearchModes)));
 
         const addFinding = (filePath, keyword, description, commitHash, commitDate) => {
+            if (findings.length >= maxTotalFindings) {
+                return false;
+            }
             const dedupeKey = [commitHash || '', filePath || '', keyword, description].join('|');
             if (seen.has(dedupeKey)) {
-                return;
+                return false;
             }
             seen.add(dedupeKey);
             findings.push(this._createKeywordHistoryResult(filePath, keyword, description, commitHash, commitDate));
+            return true;
         };
 
         try {
@@ -2326,40 +2355,46 @@ class LeakLockPanel {
 
                 const { stdout } = await execFileAsync('git', [
                     '-C', repoDir,
-                    'log', '--all', '--no-color',
-                    '--pretty=format:%H%x09%aI%x09%s'
+                    'log', '--all', '--no-color', '-z',
+                    '--pretty=format:%H%x09%aI%x09%B%x00'
                 ], { timeout: 20000 });
 
-                const lines = stdout.split('\n').filter(Boolean);
+                const records = stdout.split('\0').filter(Boolean);
                 const matchCountByKeyword = new Map(keywordConfig.keywords.map((kw) => [kw, 0]));
-                for (const line of lines) {
-                    const firstTab = line.indexOf('\t');
-                    const secondTab = firstTab >= 0 ? line.indexOf('\t', firstTab + 1) : -1;
+                for (const record of records) {
+                    if (findings.length >= maxTotalFindings) {
+                        break;
+                    }
+                    const firstTab = record.indexOf('\t');
+                    const secondTab = firstTab >= 0 ? record.indexOf('\t', firstTab + 1) : -1;
                     if (firstTab < 0 || secondTab < 0) {
                         continue;
                     }
-                    const commitHash = line.slice(0, firstTab).trim();
-                    const commitDate = line.slice(firstTab + 1, secondTab).trim();
-                    const subject = line.slice(secondTab + 1).trim();
-                    const subjectLower = subject.toLowerCase();
+                    const commitHash = record.slice(0, firstTab).trim();
+                    const commitDate = record.slice(firstTab + 1, secondTab).trim();
+                    const fullMessage = record.slice(secondTab + 1).trim();
+                    const firstLineEnd = fullMessage.indexOf('\n');
+                    const previewSource = firstLineEnd >= 0 ? fullMessage.slice(0, firstLineEnd) : fullMessage;
+                    const preview = previewSource.length > 140 ? `${previewSource.slice(0, 137)}...` : previewSource;
 
                     for (const keyword of keywordConfig.keywords) {
                         const existingCount = matchCountByKeyword.get(keyword) || 0;
                         if (existingCount >= keywordConfig.maxMatchesPerKeyword) {
                             continue;
                         }
-                        if (!subjectLower.includes(keyword.toLowerCase())) {
+                        if (!this._keywordMatchesText(fullMessage, keyword)) {
                             continue;
                         }
-                        const preview = subject.length > 140 ? `${subject.slice(0, 137)}...` : subject;
-                        addFinding(
+                        const added = addFinding(
                             'git-history-reference',
                             keyword,
                             `Keyword "${keyword}" found in commit message: ${preview}`,
                             commitHash,
                             commitDate
                         );
-                        matchCountByKeyword.set(keyword, existingCount + 1);
+                        if (added) {
+                            matchCountByKeyword.set(keyword, existingCount + 1);
+                        }
                     }
                 }
             }
@@ -2369,11 +2404,14 @@ class LeakLockPanel {
                 this._updateWebviewContent();
 
                 for (const keyword of keywordConfig.keywords) {
+                    if (findings.length >= maxTotalFindings) {
+                        break;
+                    }
                     const { stdout } = await execFileAsync('git', [
                         '-C', repoDir,
                         'log', '--all', '--no-color',
                         '--pretty=format:COMMIT%x09%H%x09%aI',
-                        '--name-only',
+                        '-p',
                         '-S', keyword,
                         '--',
                         '.'
@@ -2382,6 +2420,7 @@ class LeakLockPanel {
                     const lines = stdout.split('\n');
                     let currentCommit = null;
                     let currentDate = null;
+                    let currentFile = null;
                     let perKeywordCount = 0;
                     for (const rawLine of lines) {
                         const line = rawLine.trim();
@@ -2392,19 +2431,41 @@ class LeakLockPanel {
                             const parts = line.split('\t');
                             currentCommit = parts[1] || null;
                             currentDate = parts[2] || null;
+                            currentFile = null;
+                            continue;
+                        }
+                        if (line.startsWith('diff --git ')) {
+                            const match = rawLine.match(/^diff --git a\/(.+?) b\/(.+)$/);
+                            if (match) {
+                                currentFile = match[2];
+                            }
                             continue;
                         }
                         if (!currentCommit || perKeywordCount >= keywordConfig.maxMatchesPerKeyword) {
                             continue;
                         }
-                        addFinding(
-                            line,
+                        if (!currentFile) {
+                            continue;
+                        }
+                        if (!(line.startsWith('+') || line.startsWith('-') || line.startsWith(' ')) || line.startsWith('+++') || line.startsWith('---')) {
+                            continue;
+                        }
+                        if (!this._keywordMatchesText(line.slice(1), keyword)) {
+                            continue;
+                        }
+                        const added = addFinding(
+                            currentFile,
                             keyword,
                             `Keyword "${keyword}" found in historical file content changes`,
                             currentCommit,
                             currentDate
                         );
-                        perKeywordCount++;
+                        if (added) {
+                            perKeywordCount++;
+                        }
+                        if (findings.length >= maxTotalFindings) {
+                            break;
+                        }
                     }
                 }
             }
@@ -2445,12 +2506,13 @@ class LeakLockPanel {
             return;
         }
 
+        const MAX_HASHES_TO_ENRICH = 200;
+        const hashArray = [...uniqueHashes].slice(0, MAX_HASHES_TO_ENRICH);
         const repoDir = this._scanRepoRoot || scanPath;
         const commitInfo = new Map(); // hash -> { branches, fallbackDate }
 
         // Resolve commit metadata in parallel with limited concurrency
         const CONCURRENCY = 5;
-        const hashArray = [...uniqueHashes];
 
         const resolveHash = async (hash) => {
             try {
@@ -3264,7 +3326,8 @@ class LeakLockPanel {
         return 'low';
     }
 
-    _createResult(filePath, line, secret, description, ruleName, match = null) {
+    _createResult(filePath, line, secret, description, ruleName, match = null, options = null) {
+        const normalizedOptions = options && typeof options === 'object' ? options : {};
         const relativeFile = this._getRelativeFilePath(filePath);
         const isInDependency = this._isInDependencyDirectory(relativeFile);
 
@@ -3275,6 +3338,9 @@ class LeakLockPanel {
         }
         // Also check legacy path-based detection
         isGitHistory = isGitHistory || filePath.startsWith('git-ref:') || filePath.startsWith('git-object') || filePath === 'git-history-reference';
+        if (normalizedOptions.forceGitHistory === true) {
+            isGitHistory = true;
+        }
 
         // Get dependency handling configuration
         const config = vscode.workspace.getConfiguration('leakLock');
@@ -3321,6 +3387,7 @@ class LeakLockPanel {
 
         const fullSecret = typeof secret === 'string' ? secret : String(secret);
         const displaySecret = this._truncateSecret(fullSecret);
+        const includeInCleanup = normalizedOptions.includeInCleanup !== false;
         const result = {
             file: relativeFile,
             line: line,
@@ -3330,7 +3397,9 @@ class LeakLockPanel {
             description: enhancedDescription,
             severity: severity,
             isDependency: isInDependency,
+            includeInCleanup: includeInCleanup,
             originalSeverity: this._getSeverity(ruleName),
+            ruleName: ruleName || '',
             isGitHistory: isGitHistory,
             isUntracked: isUntracked,
             commitHash: commitHash,
@@ -3422,7 +3491,7 @@ class LeakLockPanel {
                     continue;
                 }
                 const result = this._scanResults[idx];
-                if (!result || result.isDependency) {
+                if (!result || result.isDependency || result.includeInCleanup === false || result.ruleName === 'git_history_keyword') {
                     continue;
                 }
                 const secretValue = result.fullSecret || result.secret;

--- a/leakLockPanel.js
+++ b/leakLockPanel.js
@@ -1849,8 +1849,8 @@ class LeakLockPanel {
         if (this._scanResults.length === 0) {
             return `
                 <div class="scan-section">
-                    <h2>✅ No Secrets Found</h2>
-                    <p>Great! No potential secrets were detected in your repository.</p>
+                    <h2>✅ No Findings Found</h2>
+                    <p>Great! No findings (potential secrets or policy references) were detected in your repository.</p>
                 </div>
             `;
         }
@@ -2062,7 +2062,7 @@ class LeakLockPanel {
                     <button style="padding:4px 8px; background: var(--vscode-button-secondaryBackground); color: var(--vscode-button-secondaryForeground); border:none; border-radius:4px; cursor:pointer;" onclick="refetchNow()">⟳ Refetch now</button>
                 </div>
                 <div style="margin-bottom: 15px;">
-                    <strong>Found ${this._scanResults.length} potential secrets:</strong>
+                    <strong>Found ${this._scanResults.length} findings:</strong>
                     <div class="export-actions">
                         <button class="scan-button" onclick="exportScanResultsJson()">📤 Export JSON</button>
                         <button class="scan-button" onclick="printScanResults()">🖨️ Print / Save as PDF</button>
@@ -2232,7 +2232,7 @@ class LeakLockPanel {
             if (allResults.length > 0) {
                 vscode.window.showWarningMessage(`Scan complete! Found ${allResults.length} findings (potential secrets or policy references). Review them in the main panel.`);
             } else {
-                vscode.window.showInformationMessage('🎉 Scan complete! No secrets found in your repository. Your code looks secure!');
+                vscode.window.showInformationMessage('🎉 Scan complete! No findings (potential secrets or policy references) were found in your repository.');
             }
         } catch (error) {
             console.error('Scan error:', error);
@@ -2350,13 +2350,12 @@ class LeakLockPanel {
             findings.push(this._createKeywordHistoryResult(filePath, keyword, description, commitHash, commitDate));
             return true;
         };
+        const matchCountByKeyword = new Map(keywordConfig.keywords.map((kw) => [kw, 0]));
 
         try {
             if (keywordConfig.searchCommitMessages) {
                 this._scanProgress = { stage: 'process', message: 'Searching git commit messages for configured keywords...' };
                 this._updateWebviewContent();
-
-                const matchCountByKeyword = new Map(keywordConfig.keywords.map((kw) => [kw, 0]));
                 for (const keyword of keywordConfig.keywords) {
                     if (findings.length >= maxTotalFindings) {
                         break;
@@ -2408,23 +2407,25 @@ class LeakLockPanel {
                 this._scanProgress = { stage: 'process', message: 'Searching git file history for configured keywords...' };
                 this._updateWebviewContent();
 
-                for (const keyword of keywordConfig.keywords) {
-                    if (findings.length >= maxTotalFindings) {
-                        break;
-                    }
-                    if (keyword.length <= 3) {
-                        // Skip short tokens (for example "ai") in file-history mode to avoid
-                        // broad and expensive -S matches that are mostly noise.
-                        continue;
-                    }
-                    const safetyFactor = 3;
-                    const gitMaxCount = Math.max(1, keywordConfig.maxMatchesPerKeyword) * safetyFactor;
+                const fileHistoryKeywords = keywordConfig.keywords.filter((keyword) => keyword.length > 3);
+                if (fileHistoryKeywords.length > 0) {
+                    const combinedPattern = fileHistoryKeywords
+                        .map((keyword) => this._escapeRegex(keyword))
+                        .join('|');
+                    const commitSafetyFactor = 3;
+                    const gitMaxCount = Math.max(
+                        100,
+                        Math.max(1, keywordConfig.maxMatchesPerKeyword) *
+                            Math.max(1, fileHistoryKeywords.length) *
+                            commitSafetyFactor
+                    );
                     const { stdout } = await execFileAsync('git', [
                         '-C', repoDir,
                         'log', '--all', '--no-color',
                         '--pretty=format:COMMIT%x09%H%x09%aI',
                         '-p',
-                        '-S', keyword,
+                        '--pickaxe-regex',
+                        '-G', combinedPattern,
                         `--max-count=${gitMaxCount}`,
                         '--',
                         '.'
@@ -2434,8 +2435,10 @@ class LeakLockPanel {
                     let currentCommit = null;
                     let currentDate = null;
                     let currentFile = null;
-                    let perKeywordCount = 0;
                     for (const rawLine of lines) {
+                        if (findings.length >= maxTotalFindings) {
+                            break;
+                        }
                         const line = rawLine.trimEnd();
                         if (!line.trim()) {
                             continue;
@@ -2454,31 +2457,32 @@ class LeakLockPanel {
                             }
                             continue;
                         }
-                        if (!currentCommit || perKeywordCount >= keywordConfig.maxMatchesPerKeyword) {
-                            continue;
-                        }
-                        if (!currentFile) {
+                        if (!currentCommit || !currentFile) {
                             continue;
                         }
                         // Restrict to added/removed lines only; exclude diff headers.
                         if (!(line.startsWith('+') || line.startsWith('-')) || line.startsWith('+++') || line.startsWith('---')) {
                             continue;
                         }
-                        if (!this._keywordMatchesText(line.slice(1), keyword)) {
-                            continue;
-                        }
-                        const added = addFinding(
-                            currentFile,
-                            keyword,
-                            `Keyword "${keyword}" found in historical file content changes`,
-                            currentCommit,
-                            currentDate
-                        );
-                        if (added) {
-                            perKeywordCount++;
-                        }
-                        if (findings.length >= maxTotalFindings) {
-                            break;
+                        const patchLine = line.slice(1);
+                        for (const keyword of fileHistoryKeywords) {
+                            const existingCount = matchCountByKeyword.get(keyword) || 0;
+                            if (existingCount >= keywordConfig.maxMatchesPerKeyword) {
+                                continue;
+                            }
+                            if (!this._keywordMatchesText(patchLine, keyword)) {
+                                continue;
+                            }
+                            const added = addFinding(
+                                currentFile,
+                                keyword,
+                                `Keyword "${keyword}" found in historical file content changes`,
+                                currentCommit,
+                                currentDate
+                            );
+                            if (added) {
+                                matchCountByKeyword.set(keyword, existingCount + 1);
+                            }
                         }
                     }
                 }

--- a/leakLockPanel.js
+++ b/leakLockPanel.js
@@ -2350,54 +2350,57 @@ class LeakLockPanel {
             findings.push(this._createKeywordHistoryResult(filePath, keyword, description, commitHash, commitDate));
             return true;
         };
-        const matchCountByKeyword = new Map(keywordConfig.keywords.map((kw) => [kw, 0]));
+        const commitModeMatchCountByKeyword = new Map(keywordConfig.keywords.map((kw) => [kw, 0]));
+        const fileModeMatchCountByKeyword = new Map(keywordConfig.keywords.map((kw) => [kw, 0]));
 
         try {
             if (keywordConfig.searchCommitMessages) {
                 this._scanProgress = { stage: 'process', message: 'Searching git commit messages for configured keywords...' };
                 this._updateWebviewContent();
-                for (const keyword of keywordConfig.keywords) {
+                const perKeywordCap = keywordConfig.maxMatchesPerKeyword * 5;
+                const gitMaxCount = Math.max(
+                    perKeywordCap,
+                    keywordConfig.keywords.length * perKeywordCap
+                );
+                const grepArgs = keywordConfig.keywords.flatMap((keyword) => ['--grep', keyword]);
+                const { stdout } = await execFileAsync('git', [
+                    '-C', repoDir,
+                    'log', '--all', '--no-color', '-z',
+                    '--regexp-ignore-case', '--fixed-strings',
+                    ...grepArgs,
+                    `--max-count=${gitMaxCount}`,
+                    '--pretty=format:%H%x09%aI%x09%s%x00'
+                ], gitLogOptions);
+                const records = stdout.split('\0').filter(Boolean);
+                for (const record of records) {
                     if (findings.length >= maxTotalFindings) {
                         break;
                     }
-                    const perKeywordCap = keywordConfig.maxMatchesPerKeyword * 5;
-                    const { stdout } = await execFileAsync('git', [
-                        '-C', repoDir,
-                        'log', '--all', '--no-color', '-z',
-                        '--regexp-ignore-case', '--fixed-strings',
-                        '--grep', keyword,
-                        `--max-count=${perKeywordCap}`,
-                        '--pretty=format:%H%x09%aI%x09%s%x00'
-                    ], gitLogOptions);
-                    const records = stdout.split('\0').filter(Boolean);
-                    for (const record of records) {
-                        if (findings.length >= maxTotalFindings) {
-                            break;
-                        }
-                        const existingCount = matchCountByKeyword.get(keyword) || 0;
+                    const firstTab = record.indexOf('\t');
+                    const secondTab = firstTab >= 0 ? record.indexOf('\t', firstTab + 1) : -1;
+                    if (firstTab < 0 || secondTab < 0) {
+                        continue;
+                    }
+                    const commitHash = record.slice(0, firstTab).trim();
+                    const commitDate = record.slice(firstTab + 1, secondTab).trim();
+                    const subject = record.slice(secondTab + 1).trim();
+                    for (const keyword of keywordConfig.keywords) {
+                        const existingCount = commitModeMatchCountByKeyword.get(keyword) || 0;
                         if (existingCount >= keywordConfig.maxMatchesPerKeyword) {
-                            break;
-                        }
-                        const firstTab = record.indexOf('\t');
-                        const secondTab = firstTab >= 0 ? record.indexOf('\t', firstTab + 1) : -1;
-                        if (firstTab < 0 || secondTab < 0) {
                             continue;
                         }
-                        const commitHash = record.slice(0, firstTab).trim();
-                        const commitDate = record.slice(firstTab + 1, secondTab).trim();
-                        const subject = record.slice(secondTab + 1).trim();
                         if (!this._keywordMatchesText(subject, keyword)) {
                             continue;
                         }
                         const added = addFinding(
-                            'git-history-reference',
+                            'git-history:commit-message',
                             keyword,
                             `Keyword "${keyword}" found in commit ${commitHash}${commitDate ? ` (${commitDate})` : ''}`,
                             commitHash,
                             commitDate
                         );
                         if (added) {
-                            matchCountByKeyword.set(keyword, existingCount + 1);
+                            commitModeMatchCountByKeyword.set(keyword, existingCount + 1);
                         }
                     }
                 }
@@ -2424,6 +2427,7 @@ class LeakLockPanel {
                         'log', '--all', '--no-color',
                         '--pretty=format:COMMIT%x09%H%x09%aI',
                         '-p',
+                        '-U0',
                         '--pickaxe-regex',
                         '-G', combinedPattern,
                         `--max-count=${gitMaxCount}`,
@@ -2466,7 +2470,7 @@ class LeakLockPanel {
                         }
                         const patchLine = line.slice(1);
                         for (const keyword of fileHistoryKeywords) {
-                            const existingCount = matchCountByKeyword.get(keyword) || 0;
+                            const existingCount = fileModeMatchCountByKeyword.get(keyword) || 0;
                             if (existingCount >= keywordConfig.maxMatchesPerKeyword) {
                                 continue;
                             }
@@ -2481,7 +2485,7 @@ class LeakLockPanel {
                                 currentDate
                             );
                             if (added) {
-                                matchCountByKeyword.set(keyword, existingCount + 1);
+                                fileModeMatchCountByKeyword.set(keyword, existingCount + 1);
                             }
                         }
                     }
@@ -2630,7 +2634,11 @@ class LeakLockPanel {
         if (!this._scanRepoRoot || !this._trackedFiles || !this._scanPath) {
             return false;
         }
-        if (!relativeFile || relativeFile === 'scan_output' || relativeFile === 'git-history-reference' || relativeFile === 'git-history-artifact') {
+        if (!relativeFile ||
+            relativeFile === 'scan_output' ||
+            relativeFile === 'git-history-reference' ||
+            relativeFile === 'git-history-artifact' ||
+            relativeFile.startsWith('git-history:')) {
             return false;
         }
         let absPath = filePath;
@@ -3292,6 +3300,10 @@ class LeakLockPanel {
     }
 
     _getRelativeFilePath(filePath) {
+        if (typeof filePath === 'string' && filePath.startsWith('git-history:')) {
+            return filePath;
+        }
+
         // If scanning external directory (not workspace), show relative path from selected directory
         if (this._selectedDirectory) {
             // If path is absolute and starts with selected directory, make it relative
@@ -3370,7 +3382,11 @@ class LeakLockPanel {
             isGitHistory = match.provenance.some(prov => prov.kind === 'git_repo');
         }
         // Also check legacy path-based detection
-        isGitHistory = isGitHistory || filePath.startsWith('git-ref:') || filePath.startsWith('git-object') || filePath === 'git-history-reference';
+        isGitHistory = isGitHistory ||
+            filePath.startsWith('git-ref:') ||
+            filePath.startsWith('git-object') ||
+            filePath.startsWith('git-history:') ||
+            filePath === 'git-history-reference';
         if (normalizedOptions.forceGitHistory === true) {
             isGitHistory = true;
         }

--- a/leakLockPanel.js
+++ b/leakLockPanel.js
@@ -2203,6 +2203,8 @@ class LeakLockPanel {
 
             // Run the actual scan
             const scanResults = await this._runNoseyParkerScan(scanPath, tempDatastore);
+            const keywordHistoryResults = await this._scanGitHistoryForKeywords(scanPath);
+            const allResults = scanResults.concat(keywordHistoryResults);
 
             // Update progress: Processing
             this._scanProgress = { stage: 'process', message: 'Processing results...' };
@@ -2212,10 +2214,10 @@ class LeakLockPanel {
             await this._cleanupTempFiles(tempDatastore);
 
             // Enrich results with git branch names and commit dates
-            await this._enrichResultsWithGitInfo(scanResults, scanPath);
+            await this._enrichResultsWithGitInfo(allResults, scanPath);
 
             // Update results
-            this._scanResults = scanResults;
+            this._scanResults = allResults;
             this._isScanning = false;
             this._scanProgress = null;
 
@@ -2223,8 +2225,8 @@ class LeakLockPanel {
             this._updateWebviewContent();
 
             // Show completion message
-            if (scanResults.length > 0) {
-                vscode.window.showWarningMessage(`Scan complete! Found ${scanResults.length} potential secrets. Review them in the main panel.`);
+            if (allResults.length > 0) {
+                vscode.window.showWarningMessage(`Scan complete! Found ${allResults.length} potential secrets. Review them in the main panel.`);
             } else {
                 vscode.window.showInformationMessage('🎉 Scan complete! No secrets found in your repository. Your code looks secure!');
             }
@@ -2259,6 +2261,158 @@ class LeakLockPanel {
             this._scanRepoRoot = null;
             this._trackedFiles = null;
         }
+    }
+
+    _getKeywordSearchConfig() {
+        const config = vscode.workspace.getConfiguration('leakLock');
+        const enabled = !!config.get('gitHistoryKeywordSearch.enabled', false);
+        const rawKeywords = config.get('gitHistoryKeywordSearch.keywords', []);
+        const maxMatchesPerKeyword = Number(config.get('gitHistoryKeywordSearch.maxMatchesPerKeyword', 25)) || 25;
+        const searchCommitMessages = !!config.get('gitHistoryKeywordSearch.searchCommitMessages', true);
+        const searchFileHistory = !!config.get('gitHistoryKeywordSearch.searchFileHistory', true);
+
+        const keywords = Array.isArray(rawKeywords)
+            ? [...new Set(rawKeywords.map((k) => String(k || '').trim()).filter(Boolean))]
+            : [];
+
+        return {
+            enabled,
+            keywords,
+            maxMatchesPerKeyword: Math.max(1, Math.min(500, maxMatchesPerKeyword)),
+            searchCommitMessages,
+            searchFileHistory
+        };
+    }
+
+    _createKeywordHistoryResult(filePath, keyword, description, commitHash, commitDate) {
+        const result = this._createResult(
+            filePath,
+            1,
+            keyword,
+            description,
+            'git_history_keyword'
+        );
+        result.isGitHistory = true;
+        result.commitHash = commitHash || null;
+        result.commitDate = commitDate || null;
+        return result;
+    }
+
+    async _scanGitHistoryForKeywords(scanPath) {
+        const keywordConfig = this._getKeywordSearchConfig();
+        if (!keywordConfig.enabled || keywordConfig.keywords.length === 0) {
+            return [];
+        }
+
+        const repoDir = this._scanRepoRoot || scanPath;
+        const util = require('util');
+        const execFileAsync = util.promisify(execFile);
+        const findings = [];
+        const seen = new Set();
+
+        const addFinding = (filePath, keyword, description, commitHash, commitDate) => {
+            const dedupeKey = [commitHash || '', filePath || '', keyword, description].join('|');
+            if (seen.has(dedupeKey)) {
+                return;
+            }
+            seen.add(dedupeKey);
+            findings.push(this._createKeywordHistoryResult(filePath, keyword, description, commitHash, commitDate));
+        };
+
+        try {
+            if (keywordConfig.searchCommitMessages) {
+                this._scanProgress = { stage: 'process', message: 'Searching git commit messages for configured keywords...' };
+                this._updateWebviewContent();
+
+                const { stdout } = await execFileAsync('git', [
+                    '-C', repoDir,
+                    'log', '--all', '--no-color',
+                    '--pretty=format:%H%x09%aI%x09%s'
+                ], { timeout: 20000 });
+
+                const lines = stdout.split('\n').filter(Boolean);
+                const matchCountByKeyword = new Map(keywordConfig.keywords.map((kw) => [kw, 0]));
+                for (const line of lines) {
+                    const firstTab = line.indexOf('\t');
+                    const secondTab = firstTab >= 0 ? line.indexOf('\t', firstTab + 1) : -1;
+                    if (firstTab < 0 || secondTab < 0) {
+                        continue;
+                    }
+                    const commitHash = line.slice(0, firstTab).trim();
+                    const commitDate = line.slice(firstTab + 1, secondTab).trim();
+                    const subject = line.slice(secondTab + 1).trim();
+                    const subjectLower = subject.toLowerCase();
+
+                    for (const keyword of keywordConfig.keywords) {
+                        const existingCount = matchCountByKeyword.get(keyword) || 0;
+                        if (existingCount >= keywordConfig.maxMatchesPerKeyword) {
+                            continue;
+                        }
+                        if (!subjectLower.includes(keyword.toLowerCase())) {
+                            continue;
+                        }
+                        const preview = subject.length > 140 ? `${subject.slice(0, 137)}...` : subject;
+                        addFinding(
+                            'git-history-reference',
+                            keyword,
+                            `Keyword "${keyword}" found in commit message: ${preview}`,
+                            commitHash,
+                            commitDate
+                        );
+                        matchCountByKeyword.set(keyword, existingCount + 1);
+                    }
+                }
+            }
+
+            if (keywordConfig.searchFileHistory) {
+                this._scanProgress = { stage: 'process', message: 'Searching git file history for configured keywords...' };
+                this._updateWebviewContent();
+
+                for (const keyword of keywordConfig.keywords) {
+                    const { stdout } = await execFileAsync('git', [
+                        '-C', repoDir,
+                        'log', '--all', '--no-color',
+                        '--pretty=format:COMMIT%x09%H%x09%aI',
+                        '--name-only',
+                        '-S', keyword,
+                        '--',
+                        '.'
+                    ], { timeout: 20000 });
+
+                    const lines = stdout.split('\n');
+                    let currentCommit = null;
+                    let currentDate = null;
+                    let perKeywordCount = 0;
+                    for (const rawLine of lines) {
+                        const line = rawLine.trim();
+                        if (!line) {
+                            continue;
+                        }
+                        if (line.startsWith('COMMIT\t')) {
+                            const parts = line.split('\t');
+                            currentCommit = parts[1] || null;
+                            currentDate = parts[2] || null;
+                            continue;
+                        }
+                        if (!currentCommit || perKeywordCount >= keywordConfig.maxMatchesPerKeyword) {
+                            continue;
+                        }
+                        addFinding(
+                            line,
+                            keyword,
+                            `Keyword "${keyword}" found in historical file content changes`,
+                            currentCommit,
+                            currentDate
+                        );
+                        perKeywordCount++;
+                    }
+                }
+            }
+        } catch (error) {
+            console.warn('Keyword history scan skipped:', error.message);
+        }
+
+        return findings;
     }
 
     /**

--- a/leakLockPanel.js
+++ b/leakLockPanel.js
@@ -2230,7 +2230,7 @@ class LeakLockPanel {
 
             // Show completion message
             if (allResults.length > 0) {
-                vscode.window.showWarningMessage(`Scan complete! Found ${allResults.length} potential secrets. Review them in the main panel.`);
+                vscode.window.showWarningMessage(`Scan complete! Found ${allResults.length} findings (potential secrets or policy references). Review them in the main panel.`);
             } else {
                 vscode.window.showInformationMessage('🎉 Scan complete! No secrets found in your repository. Your code looks secure!');
             }
@@ -2298,14 +2298,9 @@ class LeakLockPanel {
             null,
             { forceGitHistory: true, includeInCleanup: false }
         );
-        result.isKeywordHistory = true;
         result.commitHash = commitHash || null;
         result.commitDate = commitDate || null;
         return result;
-    }
-
-    _escapeRegExp(value) {
-        return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     }
 
     _keywordMatchesText(text, keyword) {
@@ -2315,7 +2310,7 @@ class LeakLockPanel {
             return false;
         }
         if (keywordLower.length <= 3) {
-            const boundaryRegex = new RegExp(`\\b${this._escapeRegExp(keywordLower)}\\b`, 'i');
+            const boundaryRegex = new RegExp(`\\b${this._escapeRegex(keywordLower)}\\b`, 'i');
             return boundaryRegex.test(normalizedText);
         }
         return normalizedText.toLowerCase().includes(keywordLower);
@@ -2354,38 +2349,41 @@ class LeakLockPanel {
                 this._scanProgress = { stage: 'process', message: 'Searching git commit messages for configured keywords...' };
                 this._updateWebviewContent();
 
-                const { stdout } = await execFileAsync('git', [
-                    '-C', repoDir,
-                    'log', '--all', '--no-color', '-z',
-                    '--pretty=format:%H%x09%aI%x09%B%x00'
-                ], gitLogOptions);
-
-                const records = stdout.split('\0').filter(Boolean);
                 const matchCountByKeyword = new Map(keywordConfig.keywords.map((kw) => [kw, 0]));
-                for (const record of records) {
+                for (const keyword of keywordConfig.keywords) {
                     if (findings.length >= maxTotalFindings) {
                         break;
                     }
-                    const firstTab = record.indexOf('\t');
-                    const secondTab = firstTab >= 0 ? record.indexOf('\t', firstTab + 1) : -1;
-                    if (firstTab < 0 || secondTab < 0) {
-                        continue;
-                    }
-                    const commitHash = record.slice(0, firstTab).trim();
-                    const commitDate = record.slice(firstTab + 1, secondTab).trim();
-                    const fullMessage = record.slice(secondTab + 1).trim();
-                    const firstLineEnd = fullMessage.indexOf('\n');
-                    const previewSource = firstLineEnd >= 0 ? fullMessage.slice(0, firstLineEnd) : fullMessage;
-                    const preview = previewSource.length > 140 ? `${previewSource.slice(0, 137)}...` : previewSource;
-
-                    for (const keyword of keywordConfig.keywords) {
+                    const perKeywordCap = keywordConfig.maxMatchesPerKeyword * 5;
+                    const { stdout } = await execFileAsync('git', [
+                        '-C', repoDir,
+                        'log', '--all', '--no-color', '-z',
+                        '--regexp-ignore-case', '--fixed-strings',
+                        '--grep', keyword,
+                        `--max-count=${perKeywordCap}`,
+                        '--pretty=format:%H%x09%aI%x09%s%x00'
+                    ], gitLogOptions);
+                    const records = stdout.split('\0').filter(Boolean);
+                    for (const record of records) {
+                        if (findings.length >= maxTotalFindings) {
+                            break;
+                        }
                         const existingCount = matchCountByKeyword.get(keyword) || 0;
                         if (existingCount >= keywordConfig.maxMatchesPerKeyword) {
+                            break;
+                        }
+                        const firstTab = record.indexOf('\t');
+                        const secondTab = firstTab >= 0 ? record.indexOf('\t', firstTab + 1) : -1;
+                        if (firstTab < 0 || secondTab < 0) {
                             continue;
                         }
-                        if (!this._keywordMatchesText(fullMessage, keyword)) {
+                        const commitHash = record.slice(0, firstTab).trim();
+                        const commitDate = record.slice(firstTab + 1, secondTab).trim();
+                        const subject = record.slice(secondTab + 1).trim();
+                        if (!this._keywordMatchesText(subject, keyword)) {
                             continue;
                         }
+                        const preview = subject.length > 140 ? `${subject.slice(0, 137)}...` : subject;
                         const added = addFinding(
                             'git-history-reference',
                             keyword,
@@ -2478,6 +2476,14 @@ class LeakLockPanel {
             }
         } catch (error) {
             console.warn('Keyword history scan skipped:', error.message);
+            this._scanProgress = {
+                stage: 'process',
+                message: 'Keyword history scan was skipped due to a Git error. See extension logs for details.'
+            };
+            this._updateWebviewContent();
+            vscode.window.showWarningMessage(
+                'LeakLock: Keyword history scan was skipped due to a Git error. See logs for details.'
+            );
         }
 
         return findings;

--- a/leakLockPanel.js
+++ b/leakLockPanel.js
@@ -2429,6 +2429,7 @@ class LeakLockPanel {
                     const { stdout } = await execFileAsync('git', [
                         '-C', repoDir,
                         'log', '--all', '--no-color',
+                        '--regexp-ignore-case',
                         '--pretty=format:COMMIT%x09%H%x09%aI',
                         '-p',
                         '-U0',

--- a/leakLockPanel.js
+++ b/leakLockPanel.js
@@ -2330,6 +2330,7 @@ class LeakLockPanel {
         const repoDir = this._scanRepoRoot || scanPath;
         const util = require('util');
         const execFileAsync = util.promisify(execFile);
+        const gitLogOptions = { timeout: 20000, maxBuffer: 50 * 1024 * 1024 };
         const findings = [];
         const seen = new Set();
         const totalSearchModes = (keywordConfig.searchCommitMessages ? 1 : 0) + (keywordConfig.searchFileHistory ? 1 : 0);
@@ -2357,7 +2358,7 @@ class LeakLockPanel {
                     '-C', repoDir,
                     'log', '--all', '--no-color', '-z',
                     '--pretty=format:%H%x09%aI%x09%B%x00'
-                ], { timeout: 20000 });
+                ], gitLogOptions);
 
                 const records = stdout.split('\0').filter(Boolean);
                 const matchCountByKeyword = new Map(keywordConfig.keywords.map((kw) => [kw, 0]));
@@ -2407,15 +2408,21 @@ class LeakLockPanel {
                     if (findings.length >= maxTotalFindings) {
                         break;
                     }
+                    if (keyword.length <= 3) {
+                        // Skip short tokens (for example "ai") in file-history mode to avoid
+                        // broad and expensive -S matches that are mostly noise.
+                        continue;
+                    }
                     const { stdout } = await execFileAsync('git', [
                         '-C', repoDir,
                         'log', '--all', '--no-color',
                         '--pretty=format:COMMIT%x09%H%x09%aI',
                         '-p',
                         '-S', keyword,
+                        '--max-count=1000',
                         '--',
                         '.'
-                    ], { timeout: 20000 });
+                    ], gitLogOptions);
 
                     const lines = stdout.split('\n');
                     let currentCommit = null;
@@ -2423,8 +2430,8 @@ class LeakLockPanel {
                     let currentFile = null;
                     let perKeywordCount = 0;
                     for (const rawLine of lines) {
-                        const line = rawLine.trim();
-                        if (!line) {
+                        const line = rawLine.trimEnd();
+                        if (!line.trim()) {
                             continue;
                         }
                         if (line.startsWith('COMMIT\t')) {

--- a/leakLockPanel.js
+++ b/leakLockPanel.js
@@ -2337,6 +2337,8 @@ class LeakLockPanel {
         const seen = new Set();
         const totalSearchModes = (keywordConfig.searchCommitMessages ? 1 : 0) + (keywordConfig.searchFileHistory ? 1 : 0);
         const maxTotalFindings = Math.max(50, Math.min(2000, keywordConfig.keywords.length * keywordConfig.maxMatchesPerKeyword * Math.max(1, totalSearchModes)));
+        const maxCommitLogCount = 5000;
+        const maxFileHistoryLogCount = 3000;
 
         const addFinding = (filePath, keyword, description, commitHash, commitDate) => {
             if (findings.length >= maxTotalFindings) {
@@ -2358,10 +2360,11 @@ class LeakLockPanel {
                 this._scanProgress = { stage: 'process', message: 'Searching git commit messages for configured keywords...' };
                 this._updateWebviewContent();
                 const perKeywordCap = keywordConfig.maxMatchesPerKeyword * 5;
-                const gitMaxCount = Math.max(
+                const requestedMaxCount = Math.max(
                     perKeywordCap,
                     keywordConfig.keywords.length * perKeywordCap
                 );
+                const gitMaxCount = Math.min(maxCommitLogCount, requestedMaxCount);
                 const grepArgs = keywordConfig.keywords.flatMap((keyword) => ['--grep', keyword]);
                 const { stdout } = await execFileAsync('git', [
                     '-C', repoDir,
@@ -2369,7 +2372,7 @@ class LeakLockPanel {
                     '--regexp-ignore-case', '--fixed-strings',
                     ...grepArgs,
                     `--max-count=${gitMaxCount}`,
-                    '--pretty=format:%H%x09%aI%x09%s%x00'
+                    '--pretty=format:%H%x09%aI%x09%B%x00'
                 ], gitLogOptions);
                 const records = stdout.split('\0').filter(Boolean);
                 for (const record of records) {
@@ -2383,13 +2386,13 @@ class LeakLockPanel {
                     }
                     const commitHash = record.slice(0, firstTab).trim();
                     const commitDate = record.slice(firstTab + 1, secondTab).trim();
-                    const subject = record.slice(secondTab + 1).trim();
+                    const fullMessage = record.slice(secondTab + 1).trim();
                     for (const keyword of keywordConfig.keywords) {
                         const existingCount = commitModeMatchCountByKeyword.get(keyword) || 0;
                         if (existingCount >= keywordConfig.maxMatchesPerKeyword) {
                             continue;
                         }
-                        if (!this._keywordMatchesText(subject, keyword)) {
+                        if (!this._keywordMatchesText(fullMessage, keyword)) {
                             continue;
                         }
                         const added = addFinding(
@@ -2416,12 +2419,13 @@ class LeakLockPanel {
                         .map((keyword) => this._escapeRegex(keyword))
                         .join('|');
                     const commitSafetyFactor = 3;
-                    const gitMaxCount = Math.max(
+                    const requestedMaxCount = Math.max(
                         100,
                         Math.max(1, keywordConfig.maxMatchesPerKeyword) *
                             Math.max(1, fileHistoryKeywords.length) *
                             commitSafetyFactor
                     );
+                    const gitMaxCount = Math.min(maxFileHistoryLogCount, requestedMaxCount);
                     const { stdout } = await execFileAsync('git', [
                         '-C', repoDir,
                         'log', '--all', '--no-color',

--- a/leakLockPanel.js
+++ b/leakLockPanel.js
@@ -2271,7 +2271,11 @@ class LeakLockPanel {
         const config = vscode.workspace.getConfiguration('leakLock');
         const enabled = !!config.get('gitHistoryKeywordSearch.enabled', false);
         const rawKeywords = config.get('gitHistoryKeywordSearch.keywords', []);
-        const maxMatchesPerKeyword = Number(config.get('gitHistoryKeywordSearch.maxMatchesPerKeyword', 25)) || 25;
+        const rawMaxMatchesPerKeyword = config.get('gitHistoryKeywordSearch.maxMatchesPerKeyword', 25);
+        const parsedMaxMatchesPerKeyword = Number(rawMaxMatchesPerKeyword);
+        const maxMatchesPerKeyword = Number.isFinite(parsedMaxMatchesPerKeyword)
+            ? Math.floor(parsedMaxMatchesPerKeyword)
+            : 25;
         const searchCommitMessages = !!config.get('gitHistoryKeywordSearch.searchCommitMessages', true);
         const searchFileHistory = !!config.get('gitHistoryKeywordSearch.searchFileHistory', true);
 
@@ -2383,11 +2387,10 @@ class LeakLockPanel {
                         if (!this._keywordMatchesText(subject, keyword)) {
                             continue;
                         }
-                        const preview = subject.length > 140 ? `${subject.slice(0, 137)}...` : subject;
                         const added = addFinding(
                             'git-history-reference',
                             keyword,
-                            `Keyword "${keyword}" found in commit message: ${preview}`,
+                            `Keyword "${keyword}" found in commit ${commitHash}${commitDate ? ` (${commitDate})` : ''}`,
                             commitHash,
                             commitDate
                         );
@@ -2411,13 +2414,15 @@ class LeakLockPanel {
                         // broad and expensive -S matches that are mostly noise.
                         continue;
                     }
+                    const safetyFactor = 3;
+                    const gitMaxCount = Math.max(1, keywordConfig.maxMatchesPerKeyword) * safetyFactor;
                     const { stdout } = await execFileAsync('git', [
                         '-C', repoDir,
                         'log', '--all', '--no-color',
                         '--pretty=format:COMMIT%x09%H%x09%aI',
                         '-p',
                         '-S', keyword,
-                        '--max-count=1000',
+                        `--max-count=${gitMaxCount}`,
                         '--',
                         '.'
                     ], gitLogOptions);

--- a/leakLockPanel.js
+++ b/leakLockPanel.js
@@ -2309,12 +2309,15 @@ class LeakLockPanel {
 
     _keywordMatchesText(text, keyword) {
         const normalizedText = String(text || '');
-        const keywordLower = String(keyword || '').toLowerCase();
+        const keywordStr = String(keyword || '').trim();
+        const keywordLower = keywordStr.toLowerCase();
         if (!keywordLower) {
             return false;
         }
-        if (keywordLower.length <= 3) {
-            const boundaryRegex = new RegExp(`\\b${this._escapeRegex(keywordLower)}\\b`, 'i');
+        // Reduce false positives for word-like keywords by requiring whole-word matches.
+        const isWordLike = /^[A-Za-z0-9]+$/.test(keywordStr);
+        if (isWordLike) {
+            const boundaryRegex = new RegExp(`\\b${this._escapeRegex(keywordStr)}\\b`, 'i');
             return boundaryRegex.test(normalizedText);
         }
         return normalizedText.toLowerCase().includes(keywordLower);
@@ -2457,7 +2460,8 @@ class LeakLockPanel {
                         if (!currentFile) {
                             continue;
                         }
-                        if (!(line.startsWith('+') || line.startsWith('-') || line.startsWith(' ')) || line.startsWith('+++') || line.startsWith('---')) {
+                        // Restrict to added/removed lines only; exclude diff headers.
+                        if (!(line.startsWith('+') || line.startsWith('-')) || line.startsWith('+++') || line.startsWith('---')) {
                             continue;
                         }
                         if (!this._keywordMatchesText(line.slice(1), keyword)) {
@@ -2524,8 +2528,15 @@ class LeakLockPanel {
             return;
         }
 
+        // Limit enrichment work to keep git calls bounded on large result sets.
         const MAX_HASHES_TO_ENRICH = 200;
         const hashArray = [...uniqueHashes].slice(0, MAX_HASHES_TO_ENRICH);
+        if (uniqueHashes.size > MAX_HASHES_TO_ENRICH) {
+            console.warn(
+                `[LeakLock] Git metadata enrichment limited to ${MAX_HASHES_TO_ENRICH} of ` +
+                `${uniqueHashes.size} unique commit hashes. Some findings may not include branch/date metadata.`
+            );
+        }
         const repoDir = this._scanRepoRoot || scanPath;
         const commitInfo = new Map(); // hash -> { branches, fallbackDate }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "leak-lock",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "leak-lock",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "globals": "^15.15.0"
       },

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
         "leakLock.gitHistoryKeywordSearch.keywords": {
           "type": "array",
           "default": [
-            "ai",
             "agent",
             "assistant",
             "claude",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "leak-lock",
   "description": "Developer tools to help engineers stay cybersecure without interrupting their workflows",
   "icon": "media/icon.png",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/nikolareljin/leak-lock.git"
@@ -71,6 +71,58 @@
             "Treat dependency findings the same as regular findings"
           ],
           "description": "How to handle secrets found in dependency directories (node_modules, vendor, etc.)"
+        },
+        "leakLock.gitHistoryKeywordSearch.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable attribution-policy keyword scanning in git history (commit messages and historical file content changes)."
+        },
+        "leakLock.gitHistoryKeywordSearch.searchCommitMessages": {
+          "type": "boolean",
+          "default": true,
+          "description": "When keyword history scan is enabled, search commit messages."
+        },
+        "leakLock.gitHistoryKeywordSearch.searchFileHistory": {
+          "type": "boolean",
+          "default": true,
+          "description": "When keyword history scan is enabled, search historical file content changes."
+        },
+        "leakLock.gitHistoryKeywordSearch.maxMatchesPerKeyword": {
+          "type": "number",
+          "default": 25,
+          "minimum": 1,
+          "maximum": 500,
+          "description": "Maximum number of keyword findings to collect per keyword and search mode."
+        },
+        "leakLock.gitHistoryKeywordSearch.keywords": {
+          "type": "array",
+          "default": [
+            "ai",
+            "agent",
+            "assistant",
+            "claude",
+            "codex",
+            "copilot",
+            "gemini",
+            "gpt",
+            "chatgpt",
+            "openai",
+            "anthropic",
+            "aider",
+            "cursor",
+            "windsurf",
+            "meldbot",
+            "openclaw",
+            "nanoclaw",
+            "password",
+            "token",
+            "api_key",
+            "secret"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "Keywords to detect in git history commit messages and/or file history (defaults focus on agent attribution and sensitive credential terms)."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
           "description": "When keyword history scan is enabled, search historical file content changes."
         },
         "leakLock.gitHistoryKeywordSearch.maxMatchesPerKeyword": {
-          "type": "number",
+          "type": "integer",
           "default": 25,
           "minimum": 1,
           "maximum": 500,


### PR DESCRIPTION
## Summary
- add optional git history keyword scanning for commit messages and historical file content changes
- add Leak Lock settings for enable/toggles, keyword list, and per-keyword match cap
- pre-populate defaults focused on agent-attribution terms and sensitive credential terms
- merge keyword-history findings into main scan results with commit metadata enrichment
- update README and CHANGELOG for feature usage and defaults

## Testing
- npm run lint
- npm test (fails in this environment without external network access to download VS Code test runtime)

Closes #39