### PR TITLE
fix: preserve path context in redacted printable reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.4.1
 ### Fixed
 - **Printable Report Redaction Scope**: Redacted PDF/printable reports now keep finding paths visible and redact only secret values, so remediation context is preserved.
-- **Commit-Message History Result Context**: Keyword matches from commit-message scanning now show message content in the Path column with a clear `git-history:commit-message "..."` label.
+- **Commit-Message History Result Context**: Keyword matches from commit-message scanning now use a stable path label with ID and commit hash (for example `git-history:commit-message [id:... commit:...]`) to avoid exposing raw commit message text.
 
 ## 0.4.0
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.4.1
+### Fixed
+- **Printable Report Redaction Scope**: Redacted PDF/printable reports now keep finding paths visible and redact only secret values, so remediation context is preserved.
+- **Commit-Message History Result Context**: Keyword matches from commit-message scanning now show message content in the Path column with a clear `git-history:commit-message "..."` label.
+
 ## 0.4.0
 ### Added
 - **Keyword Search in Git History**: Optional scanning for configured keywords in commit messages and historical file content changes ([#39](https://github.com/nikolareljin/leak-lock/issues/39))

--- a/leakLockPanel.js
+++ b/leakLockPanel.js
@@ -2307,15 +2307,22 @@ class LeakLockPanel {
         return result;
     }
 
+    _stableHash(input) {
+        const str = String(input || '');
+        let hash = 0;
+        for (let i = 0; i < str.length; i++) {
+            const charCode = str.charCodeAt(i);
+            hash = ((hash << 5) - hash) + charCode;
+            hash |= 0;
+        }
+        return (hash >>> 0).toString(16);
+    }
+
     _formatCommitMessagePathLabel(commitMessage) {
         const normalizedMessage = String(commitMessage || '').replace(/\s+/g, ' ').trim();
-        const fallbackMessage = '(empty commit message)';
-        const maxMessageLength = 120;
-        const messageForDisplay = normalizedMessage || fallbackMessage;
-        const clippedMessage = messageForDisplay.length > maxMessageLength
-            ? `${messageForDisplay.substring(0, maxMessageLength - 3)}...`
-            : messageForDisplay;
-        return `git-history:commit-message ${JSON.stringify(clippedMessage)}`;
+        const hashSource = normalizedMessage || '(empty commit message)';
+        const messageID = this._stableHash(hashSource);
+        return `git-history:commit-message [id:${messageID}]`;
     }
 
     _keywordMatchesText(text, keyword) {
@@ -2398,6 +2405,7 @@ class LeakLockPanel {
                     const commitHash = record.slice(0, firstTab).trim();
                     const commitDate = record.slice(firstTab + 1, secondTab).trim();
                     const fullMessage = record.slice(secondTab + 1).trim();
+                    const commitMessagePathLabel = this._formatCommitMessagePathLabel(fullMessage);
                     for (const keyword of keywordConfig.keywords) {
                         const existingCount = commitModeMatchCountByKeyword.get(keyword) || 0;
                         if (existingCount >= keywordConfig.maxMatchesPerKeyword) {
@@ -2407,7 +2415,7 @@ class LeakLockPanel {
                             continue;
                         }
                         const added = addFinding(
-                            this._formatCommitMessagePathLabel(fullMessage),
+                            commitMessagePathLabel,
                             keyword,
                             `Keyword "${keyword}" found in commit ${commitHash}${commitDate ? ` (${commitDate})` : ''}`,
                             commitHash,
@@ -3959,13 +3967,13 @@ class LeakLockPanel {
     }
 
     _buildPrintableScanReportHtml(options = {}) {
-        const redactSensitive = Boolean(options.redactSensitive);
+        const redactSecrets = Boolean(options.redactSensitive);
         const generatedAt = new Date().toLocaleString();
         const rows = this._scanResults.map((result) => `
             <tr>
                 <td>${escapeHtml(result.file || '')}</td>
                 <td>${escapeHtml(String(result.line ?? ''))}</td>
-                <td>${escapeHtml(redactSensitive ? '[REDACTED_SECRET]' : (result.secret || ''))}</td>
+                <td>${escapeHtml(redactSecrets ? '[REDACTED_SECRET]' : (result.secret || ''))}</td>
                 <td>${escapeHtml(result.severity || '')}</td>
                 <td>${escapeHtml(result.description || '')}</td>
             </tr>
@@ -3988,7 +3996,7 @@ class LeakLockPanel {
 </head>
 <body>
   <h1>Leak Lock Scan Report</h1>
-  <div class="meta">Generated: ${escapeHtml(generatedAt)} | Findings: ${this._scanResults.length} | Redacted: ${redactSensitive ? 'yes' : 'no'}</div>
+  <div class="meta">Generated: ${escapeHtml(generatedAt)} | Findings: ${this._scanResults.length} | Secrets redacted: ${redactSecrets ? 'yes' : 'no'}</div>
   <table>
     <thead>
       <tr>

--- a/leakLockPanel.js
+++ b/leakLockPanel.js
@@ -2318,13 +2318,10 @@ class LeakLockPanel {
         return (hash >>> 0).toString(16);
     }
 
-    _formatCommitMessagePathLabel(commitMessage, commitHash) {
-        const normalizedMessage = String(commitMessage || '').replace(/\s+/g, ' ').trim();
-        const effectiveMessage = normalizedMessage || '(empty commit message)';
+    _formatCommitMessagePathLabel(_commitMessage, commitHash) {
         const normalizedCommitHash = commitHash ? String(commitHash).trim() : '';
-        const hashSource = normalizedCommitHash
-            ? `${normalizedCommitHash}|${effectiveMessage}`
-            : effectiveMessage;
+        // Derive the ID from commit hash only to avoid encoding any commit-message information.
+        const hashSource = normalizedCommitHash || 'no-commit-hash';
         const messageID = this._stableHash(hashSource);
         if (normalizedCommitHash) {
             return `git-history:commit-message [id:${messageID} commit:${normalizedCommitHash}]`;

--- a/leakLockPanel.js
+++ b/leakLockPanel.js
@@ -2307,6 +2307,17 @@ class LeakLockPanel {
         return result;
     }
 
+    _formatCommitMessagePathLabel(commitMessage) {
+        const normalizedMessage = String(commitMessage || '').replace(/\s+/g, ' ').trim();
+        const fallbackMessage = '(empty commit message)';
+        const maxMessageLength = 120;
+        const messageForDisplay = normalizedMessage || fallbackMessage;
+        const clippedMessage = messageForDisplay.length > maxMessageLength
+            ? `${messageForDisplay.substring(0, maxMessageLength - 3)}...`
+            : messageForDisplay;
+        return `git-history:commit-message ${JSON.stringify(clippedMessage)}`;
+    }
+
     _keywordMatchesText(text, keyword) {
         const normalizedText = String(text || '');
         const keywordStr = String(keyword || '').trim();
@@ -2396,7 +2407,7 @@ class LeakLockPanel {
                             continue;
                         }
                         const added = addFinding(
-                            'git-history:commit-message',
+                            this._formatCommitMessagePathLabel(fullMessage),
                             keyword,
                             `Keyword "${keyword}" found in commit ${commitHash}${commitDate ? ` (${commitDate})` : ''}`,
                             commitHash,
@@ -3952,7 +3963,7 @@ class LeakLockPanel {
         const generatedAt = new Date().toLocaleString();
         const rows = this._scanResults.map((result) => `
             <tr>
-                <td>${escapeHtml(redactSensitive ? '[REDACTED_PATH]' : (result.file || ''))}</td>
+                <td>${escapeHtml(result.file || '')}</td>
                 <td>${escapeHtml(String(result.line ?? ''))}</td>
                 <td>${escapeHtml(redactSensitive ? '[REDACTED_SECRET]' : (result.secret || ''))}</td>
                 <td>${escapeHtml(result.severity || '')}</td>
@@ -4003,15 +4014,15 @@ class LeakLockPanel {
                 return;
             }
             const printMode = await vscode.window.showWarningMessage(
-                'Printing creates an HTML report on disk before opening the browser print dialog. Full output may include secret snippets and file paths. Choose redacted/full output and where to save it.',
+                'Printing creates an HTML report on disk before opening the browser print dialog. Secret-redacted output hides secret values but still keeps file/message paths visible for remediation context.',
                 { modal: true },
-                'Save redacted printable report',
+                'Save secret-redacted printable report',
                 'Save full printable report'
             );
             if (!printMode) {
                 return;
             }
-            const redactSensitive = printMode === 'Save redacted printable report';
+            const redactSensitive = printMode === 'Save secret-redacted printable report';
 
             const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
             // Avoid /tmp for browser-print handoff on Linux sandboxed browsers.
@@ -4022,7 +4033,7 @@ class LeakLockPanel {
             const targetUri = await vscode.window.showSaveDialog({
                 defaultUri,
                 filters: { 'HTML files': ['html'] },
-                saveLabel: redactSensitive ? 'Save redacted printable report' : 'Save printable report'
+                saveLabel: redactSensitive ? 'Save secret-redacted printable report' : 'Save printable report'
             });
             if (!targetUri) {
                 return;

--- a/leakLockPanel.js
+++ b/leakLockPanel.js
@@ -2318,10 +2318,17 @@ class LeakLockPanel {
         return (hash >>> 0).toString(16);
     }
 
-    _formatCommitMessagePathLabel(commitMessage) {
+    _formatCommitMessagePathLabel(commitMessage, commitHash) {
         const normalizedMessage = String(commitMessage || '').replace(/\s+/g, ' ').trim();
-        const hashSource = normalizedMessage || '(empty commit message)';
+        const effectiveMessage = normalizedMessage || '(empty commit message)';
+        const normalizedCommitHash = commitHash ? String(commitHash).trim() : '';
+        const hashSource = normalizedCommitHash
+            ? `${normalizedCommitHash}|${effectiveMessage}`
+            : effectiveMessage;
         const messageID = this._stableHash(hashSource);
+        if (normalizedCommitHash) {
+            return `git-history:commit-message [id:${messageID} commit:${normalizedCommitHash}]`;
+        }
         return `git-history:commit-message [id:${messageID}]`;
     }
 
@@ -2405,7 +2412,7 @@ class LeakLockPanel {
                     const commitHash = record.slice(0, firstTab).trim();
                     const commitDate = record.slice(firstTab + 1, secondTab).trim();
                     const fullMessage = record.slice(secondTab + 1).trim();
-                    const commitMessagePathLabel = this._formatCommitMessagePathLabel(fullMessage);
+                    const commitMessagePathLabel = this._formatCommitMessagePathLabel(fullMessage, commitHash);
                     for (const keyword of keywordConfig.keywords) {
                         const existingCount = commitModeMatchCountByKeyword.get(keyword) || 0;
                         if (existingCount >= keywordConfig.maxMatchesPerKeyword) {
@@ -3967,7 +3974,9 @@ class LeakLockPanel {
     }
 
     _buildPrintableScanReportHtml(options = {}) {
-        const redactSecrets = Boolean(options.redactSensitive);
+        const redactSecrets = (typeof options.redactSecrets === 'boolean')
+            ? options.redactSecrets
+            : Boolean(options.redactSensitive);
         const generatedAt = new Date().toLocaleString();
         const rows = this._scanResults.map((result) => `
             <tr>
@@ -4030,7 +4039,7 @@ class LeakLockPanel {
             if (!printMode) {
                 return;
             }
-            const redactSensitive = printMode === 'Save secret-redacted printable report';
+            const redactSecrets = printMode === 'Save secret-redacted printable report';
 
             const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
             // Avoid /tmp for browser-print handoff on Linux sandboxed browsers.
@@ -4041,13 +4050,13 @@ class LeakLockPanel {
             const targetUri = await vscode.window.showSaveDialog({
                 defaultUri,
                 filters: { 'HTML files': ['html'] },
-                saveLabel: redactSensitive ? 'Save secret-redacted printable report' : 'Save printable report'
+                saveLabel: redactSecrets ? 'Save secret-redacted printable report' : 'Save printable report'
             });
             if (!targetUri) {
                 return;
             }
 
-            const reportHtml = this._buildPrintableScanReportHtml({ redactSensitive });
+            const reportHtml = this._buildPrintableScanReportHtml({ redactSecrets });
             await vscode.workspace.fs.writeFile(targetUri, Buffer.from(reportHtml, 'utf8'));
             const opened = await vscode.env.openExternal(targetUri);
             if (!opened) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "leak-lock",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "leak-lock",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "globals": "^15.15.0"
       },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "leak-lock",
   "description": "Developer tools to help engineers stay cybersecure without interrupting their workflows",
   "icon": "media/icon.png",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/nikolareljin/leak-lock.git"


### PR DESCRIPTION
Summary
- keep finding paths visible in printable report exports while redacting secret values only
- represent commit-message keyword findings with stable non-message labels in the Path column, format: git-history:commit-message [id:<id> commit:<hash>]
- ensure the label ID is derived from commit hash only (no commit-message text influence)
- align changelog wording with implemented behavior

Validation
- node --check leakLockPanel.js
- npm run lint (times out after 90s in this environment; no diagnostics emitted before timeout)
