### PR TITLE
feat: extend git history search to arbitrary text and filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.5.0
+### Added
+- **Expanded Git-History Text Search**: Supports arbitrary text terms across commit messages and historical file content without skipping short terms.
+- **Git-History Filename Search**: Added optional filename matching mode via `leakLock.gitHistoryKeywordSearch.searchFileNames`.
+
 ## 0.4.1
 ### Fixed
 - **Printable Report Redaction Scope**: Redacted PDF/printable reports now keep finding paths visible and redact only secret values, so remediation context is preserved.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.5.0
 ### Added
 - **Expanded Git-History Text Search**: Supports arbitrary text terms across commit messages and historical file content without skipping short terms.
-- **Git-History Filename Search**: Added optional filename matching mode via `leakLock.gitHistoryKeywordSearch.searchFileNames`.
+- **Git-History Filename Search**: Added optional filename matching mode via `leakLock.gitHistoryKeywordSearch.searchFileNames` (disabled by default / opt-in).
 
 ## 0.4.1
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ code --install-extension leak-lock-0.0.1.vsix
   - `leakLock.gitHistoryKeywordSearch.searchFileHistory`
   - `leakLock.gitHistoryKeywordSearch.searchFileNames`
   - `leakLock.gitHistoryKeywordSearch.maxMatchesPerKeyword`
+  - `leakLock.gitHistoryKeywordSearch.shortKeywordFileHistoryMaxCount`
 
 Note: `leakLock.gitHistoryKeywordSearch.searchFileNames` is disabled by default (opt-in) because it can increase scan time on large repositories.
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,13 @@ Full-width main area interface showing:
 - Scanning controls and progress
 - Results display in wide table format
 
+## Search Git Commit messages
+
+This allows searching Git Commit history for messages with certain content. It could be useful when determining if any credentials or keywords unwillingly went out.
+
+<img width="299" height="373" alt="image" src="https://github.com/user-attachments/assets/7f526020-8803-4279-8163-ce14f9ea700c" />
+
+
 ### Scanning Process
 
 <img width="1701" height="859" alt="image" src="https://github.com/user-attachments/assets/dd8af4e9-c873-4435-9bd5-cbc60584ee73" />

--- a/README.md
+++ b/README.md
@@ -99,16 +99,18 @@ code --install-extension leak-lock-0.0.1.vsix
 - Optionally tune:
   - `leakLock.gitHistoryKeywordSearch.searchCommitMessages`
   - `leakLock.gitHistoryKeywordSearch.searchFileHistory`
+  - `leakLock.gitHistoryKeywordSearch.searchFileNames`
   - `leakLock.gitHistoryKeywordSearch.maxMatchesPerKeyword`
 
 Default keyword profile (designed for attribution-policy and secret hygiene):
 - Agent/AI attribution terms: `agent`, `assistant`, `claude`, `codex`, `copilot`, `gemini`, `gpt`, `chatgpt`, `openai`, `anthropic`, `aider`, `cursor`, `windsurf`, `meldbot`, `openclaw`, `nanoclaw`
 - Sensitive terms: `password`, `token`, `api_key`, `secret`
-Note: In file-history mode, very short keywords are skipped to reduce noise and improve performance.
+The keyword list can include arbitrary text terms and filename fragments, not only predefined security words.
 
 Example use case:
 - Detect commit messages that mention coding agents.
 - Detect potentially sensitive terms in historical file changes.
+- Detect historical filenames that include specific terms (for example `id_rsa`, `secrets`, or custom naming conventions).
 
 ### 7. Remove Unwanted Files (New)
 - Open from sidebar: click "🗑️ Remove files"

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ code --install-extension leak-lock-0.0.1.vsix
   - `leakLock.gitHistoryKeywordSearch.searchFileNames`
   - `leakLock.gitHistoryKeywordSearch.maxMatchesPerKeyword`
 
+Note: `leakLock.gitHistoryKeywordSearch.searchFileNames` is disabled by default (opt-in) because it can increase scan time on large repositories.
+
 Default keyword profile (designed for attribution-policy and secret hygiene):
 - Agent/AI attribution terms: `agent`, `assistant`, `claude`, `codex`, `copilot`, `gemini`, `gpt`, `chatgpt`, `openai`, `anthropic`, `aider`, `cursor`, `windsurf`, `meldbot`, `openclaw`, `nanoclaw`
 - Sensitive terms: `password`, `token`, `api_key`, `secret`

--- a/leakLockPanel.js
+++ b/leakLockPanel.js
@@ -2702,6 +2702,15 @@ class LeakLockPanel {
                         if (flushText) {
                             stdoutBuffer += flushText;
                         }
+                        let nulIndex = stdoutBuffer.indexOf('\0');
+                        while (nulIndex !== -1) {
+                            const record = stdoutBuffer.slice(0, nulIndex);
+                            if (record) {
+                                processNameStatusRecord(record);
+                            }
+                            stdoutBuffer = stdoutBuffer.slice(nulIndex + 1);
+                            nulIndex = stdoutBuffer.indexOf('\0');
+                        }
                         if (stdoutBuffer) {
                             processNameStatusRecord(stdoutBuffer);
                             stdoutBuffer = '';

--- a/leakLockPanel.js
+++ b/leakLockPanel.js
@@ -2396,7 +2396,8 @@ class LeakLockPanel {
             keyword,
             matches: this._buildKeywordMatcher(keyword, options)
         }));
-        const commitKeywordMatchers = buildKeywordMatchers(keywordConfig.keywords, { matchFragments: false });
+        // Commit-message prefilter uses git --grep substring semantics; keep JS matcher aligned.
+        const commitKeywordMatchers = buildKeywordMatchers(keywordConfig.keywords, { matchFragments: true });
         const fileHistoryKeywordMatchers = buildKeywordMatchers(keywordConfig.keywords, { matchFragments: false });
         const fileNameKeywordMatchers = buildKeywordMatchers(keywordConfig.keywords, { matchFragments: true });
 
@@ -2462,7 +2463,11 @@ class LeakLockPanel {
                 const fileHistoryKeywords = keywordConfig.keywords;
                 if (fileHistoryKeywords.length > 0) {
                     const combinedPattern = fileHistoryKeywords
-                        .map((keyword) => this._escapeRegex(keyword))
+                        .map((keyword) => {
+                            const escaped = this._escapeRegex(keyword);
+                            const isWordLike = /^[A-Za-z0-9]+$/.test(keyword);
+                            return isWordLike ? `\\b${escaped}\\b` : escaped;
+                        })
                         .join('|');
                     const commitSafetyFactor = 3;
                     const requestedMaxCount = Math.max(

--- a/leakLockPanel.js
+++ b/leakLockPanel.js
@@ -2279,7 +2279,7 @@ class LeakLockPanel {
             : 25;
         const searchCommitMessages = !!config.get('gitHistoryKeywordSearch.searchCommitMessages', true);
         const searchFileHistory = !!config.get('gitHistoryKeywordSearch.searchFileHistory', true);
-        const searchFileNames = !!config.get('gitHistoryKeywordSearch.searchFileNames', true);
+        const searchFileNames = !!config.get('gitHistoryKeywordSearch.searchFileNames', false);
 
         const keywords = Array.isArray(rawKeywords)
             ? [...new Set(rawKeywords.map((k) => String(k || '').trim()).filter(Boolean))]
@@ -2340,7 +2340,12 @@ class LeakLockPanel {
             return () => false;
         }
         if (matchFragments) {
-            return (candidateText) => String(candidateText || '').toLowerCase().includes(keywordLower);
+            return (candidateText) => {
+                if (candidateText && typeof candidateText === 'object' && typeof candidateText.lowerText === 'string') {
+                    return candidateText.lowerText.includes(keywordLower);
+                }
+                return String(candidateText || '').toLowerCase().includes(keywordLower);
+            };
         }
         // Reduce false positives for word-like keywords by requiring whole-word matches.
         const isWordLike = /^[A-Za-z0-9]+$/.test(keywordStr);
@@ -2387,9 +2392,13 @@ class LeakLockPanel {
         const commitModeMatchCountByKeyword = new Map(keywordConfig.keywords.map((kw) => [kw, 0]));
         const fileModeMatchCountByKeyword = new Map(keywordConfig.keywords.map((kw) => [kw, 0]));
         const fileNameModeMatchCountByKeyword = new Map(keywordConfig.keywords.map((kw) => [kw, 0]));
-        const commitKeywordMatchers = keywordConfig.keywords.map((keyword) => ({ keyword, matches: this._buildKeywordMatcher(keyword, { matchFragments: false }) }));
-        const fileHistoryKeywordMatchers = keywordConfig.keywords.map((keyword) => ({ keyword, matches: this._buildKeywordMatcher(keyword, { matchFragments: false }) }));
-        const fileNameKeywordMatchers = keywordConfig.keywords.map((keyword) => ({ keyword, matches: this._buildKeywordMatcher(keyword, { matchFragments: true }) }));
+        const buildKeywordMatchers = (keywords, options = {}) => keywords.map((keyword) => ({
+            keyword,
+            matches: this._buildKeywordMatcher(keyword, options)
+        }));
+        const commitKeywordMatchers = buildKeywordMatchers(keywordConfig.keywords, { matchFragments: false });
+        const fileHistoryKeywordMatchers = buildKeywordMatchers(keywordConfig.keywords, { matchFragments: false });
+        const fileNameKeywordMatchers = buildKeywordMatchers(keywordConfig.keywords, { matchFragments: true });
 
         try {
             if (keywordConfig.searchCommitMessages) {
@@ -2555,6 +2564,7 @@ class LeakLockPanel {
                     let currentCommit = null;
                     let currentDate = null;
                     let stdoutBuffer = '';
+                    let stdoutBufferIndex = 0;
                     let stderrBuffer = '';
                     let pendingNameStatus = null;
                     let stoppedEarly = false;
@@ -2591,12 +2601,13 @@ class LeakLockPanel {
                             return;
                         }
                         for (const fileNamePath of filePaths) {
+                            const fileNamePathLower = String(fileNamePath || '').toLowerCase();
                             for (const { keyword, matches } of fileNameKeywordMatchers) {
                                 const existingCount = fileNameModeMatchCountByKeyword.get(keyword) || 0;
                                 if (existingCount >= perKeywordCap) {
                                     continue;
                                 }
-                                if (!matches(fileNamePath)) {
+                                if (!matches({ lowerText: fileNamePathLower })) {
                                     continue;
                                 }
                                 const added = addFinding(
@@ -2678,15 +2689,25 @@ class LeakLockPanel {
                         };
                     };
 
+                    const processStdoutBufferRecords = () => {
+                        let nulIndex = stdoutBuffer.indexOf('\0', stdoutBufferIndex);
+                        while (nulIndex !== -1) {
+                            const record = stdoutBuffer.slice(stdoutBufferIndex, nulIndex);
+                            stdoutBufferIndex = nulIndex + 1;
+                            processNameStatusRecord(record);
+                            nulIndex = stdoutBuffer.indexOf('\0', stdoutBufferIndex);
+                        }
+
+                        // Avoid unbounded growth while minimizing repeated string allocations.
+                        if (stdoutBufferIndex > 1024 * 1024) {
+                            stdoutBuffer = stdoutBuffer.slice(stdoutBufferIndex);
+                            stdoutBufferIndex = 0;
+                        }
+                    };
+
                     gitLog.stdout.on('data', (chunk) => {
                         stdoutBuffer += stdoutDecoder.write(chunk);
-                        let nulIndex = stdoutBuffer.indexOf('\0');
-                        while (nulIndex !== -1) {
-                            const record = stdoutBuffer.slice(0, nulIndex);
-                            stdoutBuffer = stdoutBuffer.slice(nulIndex + 1);
-                            processNameStatusRecord(record);
-                            nulIndex = stdoutBuffer.indexOf('\0');
-                        }
+                        processStdoutBufferRecords();
                     });
 
                     gitLog.stderr.on('data', (chunk) => {
@@ -2702,19 +2723,12 @@ class LeakLockPanel {
                         if (flushText) {
                             stdoutBuffer += flushText;
                         }
-                        let nulIndex = stdoutBuffer.indexOf('\0');
-                        while (nulIndex !== -1) {
-                            const record = stdoutBuffer.slice(0, nulIndex);
-                            if (record) {
-                                processNameStatusRecord(record);
-                            }
-                            stdoutBuffer = stdoutBuffer.slice(nulIndex + 1);
-                            nulIndex = stdoutBuffer.indexOf('\0');
+                        processStdoutBufferRecords();
+                        if (stdoutBufferIndex < stdoutBuffer.length) {
+                            processNameStatusRecord(stdoutBuffer.slice(stdoutBufferIndex));
                         }
-                        if (stdoutBuffer) {
-                            processNameStatusRecord(stdoutBuffer);
-                            stdoutBuffer = '';
-                        }
+                        stdoutBuffer = '';
+                        stdoutBufferIndex = 0;
                         if (stoppedEarly) {
                             settleResolve();
                             return;
@@ -2728,7 +2742,14 @@ class LeakLockPanel {
                             return;
                         }
                         const reason = signal ? `signal ${signal}` : `exit code ${code}`;
-                        settleReject(new Error(`git log filename history failed (${reason}): ${stderrBuffer.trim()}`));
+                        const stderrSnippet = stderrBuffer.trim();
+                        const maxStderrLength = 600;
+                        const truncatedStderr = stderrSnippet.length > maxStderrLength
+                            ? `${stderrSnippet.slice(0, maxStderrLength)}...`
+                            : stderrSnippet;
+                        const context = `maxCount=${gitMaxCount}`;
+                        const errorDetail = truncatedStderr ? `: ${truncatedStderr}` : '';
+                        settleReject(new Error(`git log filename history failed (${reason}, ${context})${errorDetail}`));
                     });
                 });
             }

--- a/leakLockPanel.js
+++ b/leakLockPanel.js
@@ -2380,7 +2380,7 @@ class LeakLockPanel {
             (keywordConfig.searchFileNames ? 1 : 0);
         const maxTotalFindings = Math.max(50, Math.min(2000, keywordConfig.keywords.length * keywordConfig.maxMatchesPerKeyword * Math.max(1, totalSearchModes)));
         const maxCommitLogCount = 5000;
-        const maxFileHistoryLogCount = 3000;
+        const maxFileHistoryLogCount = Math.min(5000, keywordConfig.shortKeywordFileHistoryMaxCount ?? 3000);
         const maxFileNameHistoryLogCount = 4000;
 
         const addFinding = (filePath, keyword, description, commitHash, commitDate) => {
@@ -2510,6 +2510,7 @@ class LeakLockPanel {
                             '-C', repoDir,
                             'log', '--all', '--no-color',
                             '--regexp-ignore-case',
+                            '--extended-regexp',
                             '--pretty=format:COMMIT%x09%H%x09%aI',
                             '-p',
                             '-U0',

--- a/leakLockPanel.js
+++ b/leakLockPanel.js
@@ -2462,100 +2462,127 @@ class LeakLockPanel {
 
                 const fileHistoryKeywords = keywordConfig.keywords;
                 if (fileHistoryKeywords.length > 0) {
-                    const shortestKeywordLength = fileHistoryKeywords.reduce(
-                        (minLen, keyword) => Math.min(minLen, String(keyword || '').trim().length),
-                        Number.POSITIVE_INFINITY
-                    );
-                    const combinedPattern = fileHistoryKeywords
-                        .map((keyword) => {
-                            const escaped = this._escapeRegex(keyword);
-                            // git log -G uses POSIX ERE (no \b word-boundary token).
-                            // Keep the prefilter broad and rely on JS matchers for word semantics.
-                            return escaped;
-                        })
-                        .join('|');
-                    const commitSafetyFactor = 3;
-                    const requestedMaxCount = Math.max(
-                        100,
-                        Math.max(1, keywordConfig.maxMatchesPerKeyword) *
-                            Math.max(1, fileHistoryKeywords.length) *
-                            commitSafetyFactor
-                    );
-                    let gitMaxCount = Math.min(maxFileHistoryLogCount, requestedMaxCount);
-                    if (shortestKeywordLength <= 3) {
-                        // Very short tokens can make -G match an excessive portion of history.
-                        // Clamp commit count to reduce maxBuffer/timeout failures in buffered execFile mode.
-                        const shortKeywordCap = 300;
-                        gitMaxCount = Math.max(100, Math.min(gitMaxCount, shortKeywordCap));
+                    const shortKeywords = [];
+                    const longKeywords = [];
+                    for (const keyword of fileHistoryKeywords) {
+                        const normalized = String(keyword || '').trim();
+                        if (!normalized) {
+                            continue;
+                        }
+                        if (normalized.length <= 3) {
+                            shortKeywords.push(normalized);
+                        } else {
+                            longKeywords.push(normalized);
+                        }
                     }
-                    const { stdout } = await execFileAsync('git', [
-                        '-C', repoDir,
-                        'log', '--all', '--no-color',
-                        '--regexp-ignore-case',
-                        '--pretty=format:COMMIT%x09%H%x09%aI',
-                        '-p',
-                        '-U0',
-                        '--pickaxe-regex',
-                        '-G', combinedPattern,
-                        `--max-count=${gitMaxCount}`,
-                        '--',
-                        '.'
-                    ], gitLogOptions);
 
-                    const lines = stdout.split('\n');
-                    let currentCommit = null;
-                    let currentDate = null;
-                    let currentFile = null;
-                    for (const rawLine of lines) {
-                        if (findings.length >= maxTotalFindings) {
-                            break;
+                    const runFileHistoryPass = async (passKeywords, options = {}) => {
+                        if (!Array.isArray(passKeywords) || passKeywords.length === 0) {
+                            return;
                         }
-                        const line = rawLine.trimEnd();
-                        if (!line.trim()) {
-                            continue;
+                        const combinedPattern = passKeywords
+                            .map((keyword) => {
+                                const escaped = this._escapeRegex(keyword);
+                                // git log -G uses POSIX ERE (no \b word-boundary token).
+                                // Keep the prefilter broad and rely on JS matchers for word semantics.
+                                return escaped;
+                            })
+                            .join('|');
+                        const commitSafetyFactor = 3;
+                        const requestedMaxCount = Math.max(
+                            100,
+                            Math.max(1, keywordConfig.maxMatchesPerKeyword) *
+                                Math.max(1, passKeywords.length) *
+                                commitSafetyFactor
+                        );
+                        let gitMaxCount = Math.min(maxFileHistoryLogCount, requestedMaxCount);
+                        if (Number.isFinite(options.maxCountCap) && options.maxCountCap > 0) {
+                            gitMaxCount = Math.max(100, Math.min(gitMaxCount, options.maxCountCap));
                         }
-                        if (line.startsWith('COMMIT\t')) {
-                            const parts = line.split('\t');
-                            currentCommit = parts[1] || null;
-                            currentDate = parts[2] || null;
-                            currentFile = null;
-                            continue;
-                        }
-                        if (line.startsWith('diff --git ')) {
-                            const match = rawLine.match(/^diff --git a\/(.+?) b\/(.+)$/);
-                            if (match) {
-                                currentFile = match[2];
+
+                        const { stdout } = await execFileAsync('git', [
+                            '-C', repoDir,
+                            'log', '--all', '--no-color',
+                            '--regexp-ignore-case',
+                            '--pretty=format:COMMIT%x09%H%x09%aI',
+                            '-p',
+                            '-U0',
+                            '--pickaxe-regex',
+                            '-G', combinedPattern,
+                            `--max-count=${gitMaxCount}`,
+                            '--',
+                            '.'
+                        ], gitLogOptions);
+
+                        const matcherMap = new Map();
+                        for (const keyword of passKeywords) {
+                            const matcherEntry = fileHistoryKeywordMatchers.find((entry) => entry.keyword === keyword);
+                            if (matcherEntry) {
+                                matcherMap.set(keyword, matcherEntry.matches);
                             }
-                            continue;
                         }
-                        if (!currentCommit || !currentFile) {
-                            continue;
-                        }
-                        // Restrict to added/removed lines only; exclude diff headers.
-                        if (!(line.startsWith('+') || line.startsWith('-')) || line.startsWith('+++') || line.startsWith('---')) {
-                            continue;
-                        }
-                        const patchLine = line.slice(1);
-                        for (const { keyword, matches } of fileHistoryKeywordMatchers) {
-                            const existingCount = fileModeMatchCountByKeyword.get(keyword) || 0;
-                            if (existingCount >= keywordConfig.maxMatchesPerKeyword) {
+
+                        const lines = stdout.split('\n');
+                        let currentCommit = null;
+                        let currentDate = null;
+                        let currentFile = null;
+                        for (const rawLine of lines) {
+                            if (findings.length >= maxTotalFindings) {
+                                break;
+                            }
+                            const line = rawLine.trimEnd();
+                            if (!line.trim()) {
                                 continue;
                             }
-                            if (!matches(patchLine)) {
+                            if (line.startsWith('COMMIT\t')) {
+                                const parts = line.split('\t');
+                                currentCommit = parts[1] || null;
+                                currentDate = parts[2] || null;
+                                currentFile = null;
                                 continue;
                             }
-                            const added = addFinding(
-                                currentFile,
-                                keyword,
-                                `Keyword "${keyword}" found in historical file content changes`,
-                                currentCommit,
-                                currentDate
-                            );
-                            if (added) {
-                                fileModeMatchCountByKeyword.set(keyword, existingCount + 1);
+                            if (line.startsWith('diff --git ')) {
+                                const match = rawLine.match(/^diff --git a\/(.+?) b\/(.+)$/);
+                                if (match) {
+                                    currentFile = match[2];
+                                }
+                                continue;
+                            }
+                            if (!currentCommit || !currentFile) {
+                                continue;
+                            }
+                            // Restrict to added/removed lines only; exclude diff headers.
+                            if (!(line.startsWith('+') || line.startsWith('-')) || line.startsWith('+++') || line.startsWith('---')) {
+                                continue;
+                            }
+                            const patchLine = line.slice(1);
+                            for (const keyword of passKeywords) {
+                                const existingCount = fileModeMatchCountByKeyword.get(keyword) || 0;
+                                if (existingCount >= keywordConfig.maxMatchesPerKeyword) {
+                                    continue;
+                                }
+                                const matches = matcherMap.get(keyword);
+                                if (!matches || !matches(patchLine)) {
+                                    continue;
+                                }
+                                const added = addFinding(
+                                    currentFile,
+                                    keyword,
+                                    `Keyword "${keyword}" found in historical file content changes`,
+                                    currentCommit,
+                                    currentDate
+                                );
+                                if (added) {
+                                    fileModeMatchCountByKeyword.set(keyword, existingCount + 1);
+                                }
                             }
                         }
-                    }
+                    };
+
+                    // Process longer keywords with full history window.
+                    await runFileHistoryPass(longKeywords);
+                    // Process short/high-frequency keywords separately with tighter git max-count cap.
+                    await runFileHistoryPass(shortKeywords, { maxCountCap: 300 });
                 }
             }
 
@@ -2571,7 +2598,7 @@ class LeakLockPanel {
                     'log', '--all', '--no-color',
                     '--name-status',
                     '-z',
-                    '--pretty=format:COMMIT%x09%H%x09%aI%x00',
+                    '--pretty=format:%H%x09%aI%x00',
                     `--max-count=${gitMaxCount}`,
                     '--',
                     '.'
@@ -2653,10 +2680,15 @@ class LeakLockPanel {
                         if (!record) {
                             return;
                         }
-                        if (record.startsWith('COMMIT\t')) {
-                            const parts = record.split('\t');
-                            currentCommit = parts[1] || null;
-                            currentDate = parts[2] || null;
+                        // Detect commit headers by hash/date shape to avoid collisions with filenames.
+                        let commitMatch = /^([0-9a-f]{40})\t([^\t]*)/i.exec(record);
+                        if (!commitMatch) {
+                            // Backward-compatible fallback for legacy markers.
+                            commitMatch = /^COMMIT\t([0-9a-f]{40})\t([^\t]*)/i.exec(record);
+                        }
+                        if (commitMatch) {
+                            currentCommit = commitMatch[1] || null;
+                            currentDate = commitMatch[2] || null;
                             pendingNameStatus = null;
                             return;
                         }

--- a/leakLockPanel.js
+++ b/leakLockPanel.js
@@ -2,6 +2,7 @@
 
 const vscode = require('vscode');
 const { exec, spawn, execFile } = require('child_process');
+const { StringDecoder } = require('string_decoder');
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
@@ -2555,10 +2556,12 @@ class LeakLockPanel {
                     let currentDate = null;
                     let stdoutBuffer = '';
                     let stderrBuffer = '';
+                    let pendingNameStatus = null;
                     let stoppedEarly = false;
                     let timedOut = false;
                     let settled = false;
                     const gitLog = spawn('git', gitArgs, { stdio: ['ignore', 'pipe', 'pipe'] });
+                    const stdoutDecoder = new StringDecoder('utf8');
                     const timeoutMs = Math.max(1000, gitLogOptions.timeout || 20000);
                     const timeoutHandle = setTimeout(() => {
                         timedOut = true;
@@ -2583,54 +2586,8 @@ class LeakLockPanel {
                         reject(error);
                     };
 
-                    const processNameStatusRecord = (rawRecord, nextRecordSupplier) => {
-                        if (findings.length >= maxTotalFindings) {
-                            if (!stoppedEarly) {
-                                stoppedEarly = true;
-                                gitLog.kill();
-                            }
-                            return;
-                        }
-
-                        const record = String(rawRecord || '').replace(/\r$/, '');
-                        if (!record) {
-                            return;
-                        }
-                        if (record.startsWith('COMMIT\t')) {
-                            const parts = record.split('\t');
-                            currentCommit = parts[1] || null;
-                            currentDate = parts[2] || null;
-                            return;
-                        }
-                        if (!currentCommit) {
-                            return;
-                        }
-
-                        let filePaths = [];
-                        const tabIndex = record.indexOf('\t');
-                        if (tabIndex !== -1) {
-                            const status = record.slice(0, tabIndex).toUpperCase();
-                            const firstPath = record.slice(tabIndex + 1);
-                            if ((status.startsWith('R') || status.startsWith('C'))) {
-                                const secondPath = nextRecordSupplier();
-                                filePaths = [firstPath, secondPath].filter((p) => typeof p === 'string' && p.length > 0);
-                            } else {
-                                filePaths = firstPath ? [firstPath] : [];
-                            }
-                        } else {
-                            // With -z name-status, Git may emit status and paths as separate NUL records.
-                            const status = record.toUpperCase();
-                            if (status.startsWith('R') || status.startsWith('C')) {
-                                const oldPath = nextRecordSupplier();
-                                const newPath = nextRecordSupplier();
-                                filePaths = [oldPath, newPath].filter((p) => typeof p === 'string' && p.length > 0);
-                            } else {
-                                const filePath = nextRecordSupplier();
-                                filePaths = filePath ? [filePath] : [];
-                            }
-                        }
-
-                        if (filePaths.length === 0) {
+                    const emitFilePaths = (filePaths) => {
+                        if (!Array.isArray(filePaths) || filePaths.length === 0) {
                             return;
                         }
                         for (const fileNamePath of filePaths) {
@@ -2656,19 +2613,79 @@ class LeakLockPanel {
                         }
                     };
 
-                    gitLog.stdout.on('data', (chunk) => {
-                        stdoutBuffer += chunk.toString();
-                        const records = stdoutBuffer.split('\0');
-                        stdoutBuffer = records.pop() || '';
-                        for (let i = 0; i < records.length; i++) {
-                            const consumeNext = () => {
-                                if (i + 1 >= records.length) {
-                                    return '';
+                    const processNameStatusRecord = (rawRecord) => {
+                        if (findings.length >= maxTotalFindings) {
+                            if (!stoppedEarly) {
+                                stoppedEarly = true;
+                                gitLog.kill();
+                            }
+                            return;
+                        }
+
+                        const record = String(rawRecord || '');
+                        if (!record) {
+                            return;
+                        }
+                        if (record.startsWith('COMMIT\t')) {
+                            const parts = record.split('\t');
+                            currentCommit = parts[1] || null;
+                            currentDate = parts[2] || null;
+                            pendingNameStatus = null;
+                            return;
+                        }
+                        if (!currentCommit) {
+                            return;
+                        }
+
+                        if (pendingNameStatus) {
+                            pendingNameStatus.paths.push(record);
+                            if (pendingNameStatus.paths.length >= pendingNameStatus.expectedPathCount) {
+                                emitFilePaths(pendingNameStatus.paths.slice(0, pendingNameStatus.expectedPathCount));
+                                pendingNameStatus = null;
+                            }
+                            return;
+                        }
+
+                        const isNameStatusToken = (token) => /^[ACDMRTUXB][0-9]*$/i.test(token);
+                        let statusToken = '';
+                        let initialPaths = [];
+                        const tabIndex = record.indexOf('\t');
+                        if (tabIndex !== -1) {
+                            const maybeStatus = record.slice(0, tabIndex);
+                            if (isNameStatusToken(maybeStatus)) {
+                                statusToken = maybeStatus.toUpperCase();
+                                const pathFromToken = record.slice(tabIndex + 1);
+                                if (pathFromToken) {
+                                    initialPaths.push(pathFromToken);
                                 }
-                                i += 1;
-                                return records[i];
-                            };
-                            processNameStatusRecord(records[i], consumeNext);
+                            }
+                        }
+                        if (!statusToken && isNameStatusToken(record)) {
+                            statusToken = record.toUpperCase();
+                        }
+                        if (!statusToken) {
+                            return;
+                        }
+
+                        const expectedPathCount = (statusToken.startsWith('R') || statusToken.startsWith('C')) ? 2 : 1;
+                        if (initialPaths.length >= expectedPathCount) {
+                            emitFilePaths(initialPaths.slice(0, expectedPathCount));
+                            return;
+                        }
+                        pendingNameStatus = {
+                            expectedPathCount,
+                            paths: initialPaths
+                        };
+                    };
+
+                    gitLog.stdout.on('data', (chunk) => {
+                        stdoutBuffer += stdoutDecoder.write(chunk);
+                        let nulIndex = stdoutBuffer.indexOf('\0');
+                        while (nulIndex !== -1) {
+                            const record = stdoutBuffer.slice(0, nulIndex);
+                            stdoutBuffer = stdoutBuffer.slice(nulIndex + 1);
+                            processNameStatusRecord(record);
+                            nulIndex = stdoutBuffer.indexOf('\0');
                         }
                     });
 
@@ -2681,8 +2698,12 @@ class LeakLockPanel {
                     });
 
                     gitLog.on('close', (code, signal) => {
+                        const flushText = stdoutDecoder.end();
+                        if (flushText) {
+                            stdoutBuffer += flushText;
+                        }
                         if (stdoutBuffer) {
-                            processNameStatusRecord(stdoutBuffer.replace(/\r$/, ''), () => '');
+                            processNameStatusRecord(stdoutBuffer);
                             stdoutBuffer = '';
                         }
                         if (stoppedEarly) {

--- a/leakLockPanel.js
+++ b/leakLockPanel.js
@@ -2462,6 +2462,10 @@ class LeakLockPanel {
 
                 const fileHistoryKeywords = keywordConfig.keywords;
                 if (fileHistoryKeywords.length > 0) {
+                    const shortestKeywordLength = fileHistoryKeywords.reduce(
+                        (minLen, keyword) => Math.min(minLen, String(keyword || '').trim().length),
+                        Number.POSITIVE_INFINITY
+                    );
                     const combinedPattern = fileHistoryKeywords
                         .map((keyword) => {
                             const escaped = this._escapeRegex(keyword);
@@ -2477,7 +2481,13 @@ class LeakLockPanel {
                             Math.max(1, fileHistoryKeywords.length) *
                             commitSafetyFactor
                     );
-                    const gitMaxCount = Math.min(maxFileHistoryLogCount, requestedMaxCount);
+                    let gitMaxCount = Math.min(maxFileHistoryLogCount, requestedMaxCount);
+                    if (shortestKeywordLength <= 3) {
+                        // Very short tokens can make -G match an excessive portion of history.
+                        // Clamp commit count to reduce maxBuffer/timeout failures in buffered execFile mode.
+                        const shortKeywordCap = 300;
+                        gitMaxCount = Math.max(100, Math.min(gitMaxCount, shortKeywordCap));
+                    }
                     const { stdout } = await execFileAsync('git', [
                         '-C', repoDir,
                         'log', '--all', '--no-color',

--- a/leakLockPanel.js
+++ b/leakLockPanel.js
@@ -2273,10 +2273,15 @@ class LeakLockPanel {
         const enabled = !!config.get('gitHistoryKeywordSearch.enabled', false);
         const rawKeywords = config.get('gitHistoryKeywordSearch.keywords', []);
         const rawMaxMatchesPerKeyword = config.get('gitHistoryKeywordSearch.maxMatchesPerKeyword', 25);
+        const rawShortKeywordFileHistoryMaxCount = config.get('gitHistoryKeywordSearch.shortKeywordFileHistoryMaxCount', 300);
         const parsedMaxMatchesPerKeyword = Number(rawMaxMatchesPerKeyword);
+        const parsedShortKeywordFileHistoryMaxCount = Number(rawShortKeywordFileHistoryMaxCount);
         const maxMatchesPerKeyword = Number.isFinite(parsedMaxMatchesPerKeyword)
             ? Math.floor(parsedMaxMatchesPerKeyword)
             : 25;
+        const shortKeywordFileHistoryMaxCount = Number.isFinite(parsedShortKeywordFileHistoryMaxCount)
+            ? Math.floor(parsedShortKeywordFileHistoryMaxCount)
+            : 300;
         const searchCommitMessages = !!config.get('gitHistoryKeywordSearch.searchCommitMessages', true);
         const searchFileHistory = !!config.get('gitHistoryKeywordSearch.searchFileHistory', true);
         const searchFileNames = !!config.get('gitHistoryKeywordSearch.searchFileNames', false);
@@ -2289,6 +2294,7 @@ class LeakLockPanel {
             enabled,
             keywords,
             maxMatchesPerKeyword: Math.max(1, Math.min(500, maxMatchesPerKeyword)),
+            shortKeywordFileHistoryMaxCount: Math.max(100, Math.min(5000, shortKeywordFileHistoryMaxCount)),
             searchCommitMessages,
             searchFileHistory,
             searchFileNames
@@ -2581,8 +2587,10 @@ class LeakLockPanel {
 
                     // Process longer keywords with full history window.
                     await runFileHistoryPass(longKeywords);
-                    // Process short/high-frequency keywords separately with tighter git max-count cap.
-                    await runFileHistoryPass(shortKeywords, { maxCountCap: 300 });
+                    // Process short/high-frequency keywords separately with a configurable git max-count cap.
+                    await runFileHistoryPass(shortKeywords, {
+                        maxCountCap: keywordConfig.shortKeywordFileHistoryMaxCount
+                    });
                 }
             }
 
@@ -2705,7 +2713,7 @@ class LeakLockPanel {
                             return;
                         }
 
-                        const isNameStatusToken = (token) => /^[ACDMRTUXB][0-9]*$/i.test(token);
+                        const isNameStatusToken = (token) => /^[ACDMRTUXTB][0-9]*$/i.test(token);
                         let statusToken = '';
                         let initialPaths = [];
                         const tabIndex = record.indexOf('\t');

--- a/leakLockPanel.js
+++ b/leakLockPanel.js
@@ -2278,6 +2278,7 @@ class LeakLockPanel {
             : 25;
         const searchCommitMessages = !!config.get('gitHistoryKeywordSearch.searchCommitMessages', true);
         const searchFileHistory = !!config.get('gitHistoryKeywordSearch.searchFileHistory', true);
+        const searchFileNames = !!config.get('gitHistoryKeywordSearch.searchFileNames', true);
 
         const keywords = Array.isArray(rawKeywords)
             ? [...new Set(rawKeywords.map((k) => String(k || '').trim()).filter(Boolean))]
@@ -2288,7 +2289,8 @@ class LeakLockPanel {
             keywords,
             maxMatchesPerKeyword: Math.max(1, Math.min(500, maxMatchesPerKeyword)),
             searchCommitMessages,
-            searchFileHistory
+            searchFileHistory,
+            searchFileNames
         };
     }
 
@@ -2357,10 +2359,14 @@ class LeakLockPanel {
         const gitLogOptions = { timeout: 20000, maxBuffer: 50 * 1024 * 1024 };
         const findings = [];
         const seen = new Set();
-        const totalSearchModes = (keywordConfig.searchCommitMessages ? 1 : 0) + (keywordConfig.searchFileHistory ? 1 : 0);
+        const totalSearchModes =
+            (keywordConfig.searchCommitMessages ? 1 : 0) +
+            (keywordConfig.searchFileHistory ? 1 : 0) +
+            (keywordConfig.searchFileNames ? 1 : 0);
         const maxTotalFindings = Math.max(50, Math.min(2000, keywordConfig.keywords.length * keywordConfig.maxMatchesPerKeyword * Math.max(1, totalSearchModes)));
         const maxCommitLogCount = 5000;
         const maxFileHistoryLogCount = 3000;
+        const maxFileNameHistoryLogCount = 4000;
 
         const addFinding = (filePath, keyword, description, commitHash, commitDate) => {
             if (findings.length >= maxTotalFindings) {
@@ -2376,6 +2382,7 @@ class LeakLockPanel {
         };
         const commitModeMatchCountByKeyword = new Map(keywordConfig.keywords.map((kw) => [kw, 0]));
         const fileModeMatchCountByKeyword = new Map(keywordConfig.keywords.map((kw) => [kw, 0]));
+        const fileNameModeMatchCountByKeyword = new Map(keywordConfig.keywords.map((kw) => [kw, 0]));
 
         try {
             if (keywordConfig.searchCommitMessages) {
@@ -2436,7 +2443,7 @@ class LeakLockPanel {
                 this._scanProgress = { stage: 'process', message: 'Searching git file history for configured keywords...' };
                 this._updateWebviewContent();
 
-                const fileHistoryKeywords = keywordConfig.keywords.filter((keyword) => keyword.length > 3);
+                const fileHistoryKeywords = keywordConfig.keywords;
                 if (fileHistoryKeywords.length > 0) {
                     const combinedPattern = fileHistoryKeywords
                         .map((keyword) => this._escapeRegex(keyword))
@@ -2515,6 +2522,72 @@ class LeakLockPanel {
                             if (added) {
                                 fileModeMatchCountByKeyword.set(keyword, existingCount + 1);
                             }
+                        }
+                    }
+                }
+            }
+
+            if (keywordConfig.searchFileNames) {
+                this._scanProgress = { stage: 'process', message: 'Searching git history file names for configured keywords...' };
+                this._updateWebviewContent();
+
+                const perKeywordCap = keywordConfig.maxMatchesPerKeyword * 3;
+                const requestedMaxCount = Math.max(
+                    perKeywordCap,
+                    keywordConfig.keywords.length * perKeywordCap
+                );
+                const gitMaxCount = Math.min(maxFileNameHistoryLogCount, requestedMaxCount);
+                const { stdout } = await execFileAsync('git', [
+                    '-C', repoDir,
+                    'log', '--all', '--no-color',
+                    '--name-only',
+                    '--pretty=format:COMMIT%x09%H%x09%aI',
+                    `--max-count=${gitMaxCount}`,
+                    '--',
+                    '.'
+                ], gitLogOptions);
+
+                const lines = stdout.split('\n');
+                let currentCommit = null;
+                let currentDate = null;
+                for (const rawLine of lines) {
+                    if (findings.length >= maxTotalFindings) {
+                        break;
+                    }
+                    const line = rawLine.trimEnd();
+                    if (!line.trim()) {
+                        continue;
+                    }
+                    if (line.startsWith('COMMIT\t')) {
+                        const parts = line.split('\t');
+                        currentCommit = parts[1] || null;
+                        currentDate = parts[2] || null;
+                        continue;
+                    }
+                    if (!currentCommit) {
+                        continue;
+                    }
+                    const fileNamePath = line.trim();
+                    if (!fileNamePath) {
+                        continue;
+                    }
+                    for (const keyword of keywordConfig.keywords) {
+                        const existingCount = fileNameModeMatchCountByKeyword.get(keyword) || 0;
+                        if (existingCount >= keywordConfig.maxMatchesPerKeyword) {
+                            continue;
+                        }
+                        if (!this._keywordMatchesText(fileNamePath, keyword)) {
+                            continue;
+                        }
+                        const added = addFinding(
+                            fileNamePath,
+                            keyword,
+                            `Keyword "${keyword}" found in historical file name`,
+                            currentCommit,
+                            currentDate
+                        );
+                        if (added) {
+                            fileNameModeMatchCountByKeyword.set(keyword, existingCount + 1);
                         }
                     }
                 }

--- a/leakLockPanel.js
+++ b/leakLockPanel.js
@@ -2332,19 +2332,51 @@ class LeakLockPanel {
     }
 
     _keywordMatchesText(text, keyword) {
-        const normalizedText = String(text || '');
+        const matcher = this._buildKeywordMatcher(keyword, { matchFragments: false });
+        return matcher(text);
+    }
+
+    _buildKeywordMatcher(keyword, options = {}) {
+        const matchFragments = !!options.matchFragments;
         const keywordStr = String(keyword || '').trim();
         const keywordLower = keywordStr.toLowerCase();
         if (!keywordLower) {
-            return false;
+            return () => false;
+        }
+        if (matchFragments) {
+            return (candidateText) => String(candidateText || '').toLowerCase().includes(keywordLower);
         }
         // Reduce false positives for word-like keywords by requiring whole-word matches.
         const isWordLike = /^[A-Za-z0-9]+$/.test(keywordStr);
         if (isWordLike) {
             const boundaryRegex = new RegExp(`\\b${this._escapeRegex(keywordStr)}\\b`, 'i');
-            return boundaryRegex.test(normalizedText);
+            return (candidateText) => boundaryRegex.test(String(candidateText || ''));
         }
-        return normalizedText.toLowerCase().includes(keywordLower);
+        return (candidateText) => String(candidateText || '').toLowerCase().includes(keywordLower);
+    }
+
+    _extractNameStatusPaths(rawLine) {
+        const line = String(rawLine || '').trim();
+        if (!line || line.startsWith('COMMIT\t')) {
+            return [];
+        }
+        const parts = line.split('\t');
+        if (parts.length < 2) {
+            return [];
+        }
+        const status = (parts[0] || '').trim().toUpperCase();
+        if (!status) {
+            return [];
+        }
+
+        if ((status.startsWith('R') || status.startsWith('C')) && parts.length >= 3) {
+            const oldPath = (parts[1] || '').trim();
+            const newPath = (parts[2] || '').trim();
+            return [oldPath, newPath].filter(Boolean);
+        }
+
+        const filePath = (parts[1] || '').trim();
+        return filePath ? [filePath] : [];
     }
 
     async _scanGitHistoryForKeywords(scanPath) {
@@ -2383,6 +2415,9 @@ class LeakLockPanel {
         const commitModeMatchCountByKeyword = new Map(keywordConfig.keywords.map((kw) => [kw, 0]));
         const fileModeMatchCountByKeyword = new Map(keywordConfig.keywords.map((kw) => [kw, 0]));
         const fileNameModeMatchCountByKeyword = new Map(keywordConfig.keywords.map((kw) => [kw, 0]));
+        const commitKeywordMatchers = keywordConfig.keywords.map((keyword) => ({ keyword, matches: this._buildKeywordMatcher(keyword, { matchFragments: false }) }));
+        const fileHistoryKeywordMatchers = keywordConfig.keywords.map((keyword) => ({ keyword, matches: this._buildKeywordMatcher(keyword, { matchFragments: false }) }));
+        const fileNameKeywordMatchers = keywordConfig.keywords.map((keyword) => ({ keyword, matches: this._buildKeywordMatcher(keyword, { matchFragments: true }) }));
 
         try {
             if (keywordConfig.searchCommitMessages) {
@@ -2417,12 +2452,12 @@ class LeakLockPanel {
                     const commitDate = record.slice(firstTab + 1, secondTab).trim();
                     const fullMessage = record.slice(secondTab + 1).trim();
                     const commitMessagePathLabel = this._formatCommitMessagePathLabel(fullMessage, commitHash);
-                    for (const keyword of keywordConfig.keywords) {
+                    for (const { keyword, matches } of commitKeywordMatchers) {
                         const existingCount = commitModeMatchCountByKeyword.get(keyword) || 0;
                         if (existingCount >= keywordConfig.maxMatchesPerKeyword) {
                             continue;
                         }
-                        if (!this._keywordMatchesText(fullMessage, keyword)) {
+                        if (!matches(fullMessage)) {
                             continue;
                         }
                         const added = addFinding(
@@ -2504,12 +2539,12 @@ class LeakLockPanel {
                             continue;
                         }
                         const patchLine = line.slice(1);
-                        for (const keyword of fileHistoryKeywords) {
+                        for (const { keyword, matches } of fileHistoryKeywordMatchers) {
                             const existingCount = fileModeMatchCountByKeyword.get(keyword) || 0;
                             if (existingCount >= keywordConfig.maxMatchesPerKeyword) {
                                 continue;
                             }
-                            if (!this._keywordMatchesText(patchLine, keyword)) {
+                            if (!matches(patchLine)) {
                                 continue;
                             }
                             const added = addFinding(
@@ -2532,65 +2567,111 @@ class LeakLockPanel {
                 this._updateWebviewContent();
 
                 const perKeywordCap = keywordConfig.maxMatchesPerKeyword * 3;
-                const requestedMaxCount = Math.max(
-                    perKeywordCap,
-                    keywordConfig.keywords.length * perKeywordCap
-                );
+                const requestedMaxCount = Math.max(100, keywordConfig.keywords.length * perKeywordCap);
                 const gitMaxCount = Math.min(maxFileNameHistoryLogCount, requestedMaxCount);
-                const { stdout } = await execFileAsync('git', [
+                const gitArgs = [
                     '-C', repoDir,
                     'log', '--all', '--no-color',
-                    '--name-only',
+                    '--name-status',
                     '--pretty=format:COMMIT%x09%H%x09%aI',
                     `--max-count=${gitMaxCount}`,
                     '--',
                     '.'
-                ], gitLogOptions);
+                ];
+                await new Promise((resolve, reject) => {
+                    let currentCommit = null;
+                    let currentDate = null;
+                    let stdoutBuffer = '';
+                    let stderrBuffer = '';
+                    let stoppedEarly = false;
+                    const gitLog = spawn('git', gitArgs, { stdio: ['ignore', 'pipe', 'pipe'] });
 
-                const lines = stdout.split('\n');
-                let currentCommit = null;
-                let currentDate = null;
-                for (const rawLine of lines) {
-                    if (findings.length >= maxTotalFindings) {
-                        break;
-                    }
-                    const line = rawLine.trimEnd();
-                    if (!line.trim()) {
-                        continue;
-                    }
-                    if (line.startsWith('COMMIT\t')) {
-                        const parts = line.split('\t');
-                        currentCommit = parts[1] || null;
-                        currentDate = parts[2] || null;
-                        continue;
-                    }
-                    if (!currentCommit) {
-                        continue;
-                    }
-                    const fileNamePath = line.trim();
-                    if (!fileNamePath) {
-                        continue;
-                    }
-                    for (const keyword of keywordConfig.keywords) {
-                        const existingCount = fileNameModeMatchCountByKeyword.get(keyword) || 0;
-                        if (existingCount >= keywordConfig.maxMatchesPerKeyword) {
-                            continue;
+                    const processLine = (rawLine) => {
+                        if (findings.length >= maxTotalFindings) {
+                            if (!stoppedEarly) {
+                                stoppedEarly = true;
+                                gitLog.kill();
+                            }
+                            return;
                         }
-                        if (!this._keywordMatchesText(fileNamePath, keyword)) {
-                            continue;
+
+                        const line = String(rawLine || '').trimEnd();
+                        if (!line.trim()) {
+                            return;
                         }
-                        const added = addFinding(
-                            fileNamePath,
-                            keyword,
-                            `Keyword "${keyword}" found in historical file name`,
-                            currentCommit,
-                            currentDate
-                        );
-                        if (added) {
-                            fileNameModeMatchCountByKeyword.set(keyword, existingCount + 1);
+                        if (line.startsWith('COMMIT\t')) {
+                            const parts = line.split('\t');
+                            currentCommit = parts[1] || null;
+                            currentDate = parts[2] || null;
+                            return;
                         }
-                    }
-                }
+                        if (!currentCommit) {
+                            return;
+                        }
+
+                        const filePaths = this._extractNameStatusPaths(line);
+                        if (filePaths.length === 0) {
+                            return;
+                        }
+                        for (const fileNamePath of filePaths) {
+                            for (const { keyword, matches } of fileNameKeywordMatchers) {
+                                const existingCount = fileNameModeMatchCountByKeyword.get(keyword) || 0;
+                                if (existingCount >= perKeywordCap) {
+                                    continue;
+                                }
+                                if (!matches(fileNamePath)) {
+                                    continue;
+                                }
+                                const added = addFinding(
+                                    fileNamePath,
+                                    keyword,
+                                    `Keyword "${keyword}" found in historical file name`,
+                                    currentCommit,
+                                    currentDate
+                                );
+                                if (added) {
+                                    fileNameModeMatchCountByKeyword.set(keyword, existingCount + 1);
+                                }
+                            }
+                        }
+                    };
+
+                    gitLog.stdout.on('data', (chunk) => {
+                        stdoutBuffer += chunk.toString();
+                        let newlineIndex = stdoutBuffer.indexOf('\n');
+                        while (newlineIndex !== -1) {
+                            const line = stdoutBuffer.slice(0, newlineIndex).replace(/\r$/, '');
+                            stdoutBuffer = stdoutBuffer.slice(newlineIndex + 1);
+                            processLine(line);
+                            newlineIndex = stdoutBuffer.indexOf('\n');
+                        }
+                    });
+
+                    gitLog.stderr.on('data', (chunk) => {
+                        stderrBuffer += chunk.toString();
+                    });
+
+                    gitLog.on('error', (error) => {
+                        reject(error);
+                    });
+
+                    gitLog.on('close', (code, signal) => {
+                        if (stdoutBuffer) {
+                            processLine(stdoutBuffer.replace(/\r$/, ''));
+                            stdoutBuffer = '';
+                        }
+                        if (stoppedEarly) {
+                            resolve();
+                            return;
+                        }
+                        if (code === 0) {
+                            resolve();
+                            return;
+                        }
+                        const reason = signal ? `signal ${signal}` : `exit code ${code}`;
+                        reject(new Error(`git log filename history failed (${reason}): ${stderrBuffer.trim()}`));
+                    });
+                });
             }
         } catch (error) {
             console.warn('Keyword history scan skipped:', error.message);

--- a/leakLockPanel.js
+++ b/leakLockPanel.js
@@ -2465,8 +2465,9 @@ class LeakLockPanel {
                     const combinedPattern = fileHistoryKeywords
                         .map((keyword) => {
                             const escaped = this._escapeRegex(keyword);
-                            const isWordLike = /^[A-Za-z0-9]+$/.test(keyword);
-                            return isWordLike ? `\\b${escaped}\\b` : escaped;
+                            // git log -G uses POSIX ERE (no \b word-boundary token).
+                            // Keep the prefilter broad and rely on JS matchers for word semantics.
+                            return escaped;
                         })
                         .join('|');
                     const commitSafetyFactor = 3;

--- a/leakLockPanel.js
+++ b/leakLockPanel.js
@@ -2331,11 +2331,6 @@ class LeakLockPanel {
         return `git-history:commit-message [id:${messageID}]`;
     }
 
-    _keywordMatchesText(text, keyword) {
-        const matcher = this._buildKeywordMatcher(keyword, { matchFragments: false });
-        return matcher(text);
-    }
-
     _buildKeywordMatcher(keyword, options = {}) {
         const matchFragments = !!options.matchFragments;
         const keywordStr = String(keyword || '').trim();
@@ -2353,30 +2348,6 @@ class LeakLockPanel {
             return (candidateText) => boundaryRegex.test(String(candidateText || ''));
         }
         return (candidateText) => String(candidateText || '').toLowerCase().includes(keywordLower);
-    }
-
-    _extractNameStatusPaths(rawLine) {
-        const line = String(rawLine || '').trim();
-        if (!line || line.startsWith('COMMIT\t')) {
-            return [];
-        }
-        const parts = line.split('\t');
-        if (parts.length < 2) {
-            return [];
-        }
-        const status = (parts[0] || '').trim().toUpperCase();
-        if (!status) {
-            return [];
-        }
-
-        if ((status.startsWith('R') || status.startsWith('C')) && parts.length >= 3) {
-            const oldPath = (parts[1] || '').trim();
-            const newPath = (parts[2] || '').trim();
-            return [oldPath, newPath].filter(Boolean);
-        }
-
-        const filePath = (parts[1] || '').trim();
-        return filePath ? [filePath] : [];
     }
 
     async _scanGitHistoryForKeywords(scanPath) {
@@ -2566,14 +2537,15 @@ class LeakLockPanel {
                 this._scanProgress = { stage: 'process', message: 'Searching git history file names for configured keywords...' };
                 this._updateWebviewContent();
 
-                const perKeywordCap = keywordConfig.maxMatchesPerKeyword * 3;
+                const perKeywordCap = keywordConfig.maxMatchesPerKeyword;
                 const requestedMaxCount = Math.max(100, keywordConfig.keywords.length * perKeywordCap);
                 const gitMaxCount = Math.min(maxFileNameHistoryLogCount, requestedMaxCount);
                 const gitArgs = [
                     '-C', repoDir,
                     'log', '--all', '--no-color',
                     '--name-status',
-                    '--pretty=format:COMMIT%x09%H%x09%aI',
+                    '-z',
+                    '--pretty=format:COMMIT%x09%H%x09%aI%x00',
                     `--max-count=${gitMaxCount}`,
                     '--',
                     '.'
@@ -2611,7 +2583,7 @@ class LeakLockPanel {
                         reject(error);
                     };
 
-                    const processLine = (rawLine) => {
+                    const processNameStatusRecord = (rawRecord, nextRecordSupplier) => {
                         if (findings.length >= maxTotalFindings) {
                             if (!stoppedEarly) {
                                 stoppedEarly = true;
@@ -2620,12 +2592,12 @@ class LeakLockPanel {
                             return;
                         }
 
-                        const line = String(rawLine || '').trimEnd();
-                        if (!line.trim()) {
+                        const record = String(rawRecord || '').replace(/\r$/, '');
+                        if (!record) {
                             return;
                         }
-                        if (line.startsWith('COMMIT\t')) {
-                            const parts = line.split('\t');
+                        if (record.startsWith('COMMIT\t')) {
+                            const parts = record.split('\t');
                             currentCommit = parts[1] || null;
                             currentDate = parts[2] || null;
                             return;
@@ -2634,7 +2606,30 @@ class LeakLockPanel {
                             return;
                         }
 
-                        const filePaths = this._extractNameStatusPaths(line);
+                        let filePaths = [];
+                        const tabIndex = record.indexOf('\t');
+                        if (tabIndex !== -1) {
+                            const status = record.slice(0, tabIndex).toUpperCase();
+                            const firstPath = record.slice(tabIndex + 1);
+                            if ((status.startsWith('R') || status.startsWith('C'))) {
+                                const secondPath = nextRecordSupplier();
+                                filePaths = [firstPath, secondPath].filter((p) => typeof p === 'string' && p.length > 0);
+                            } else {
+                                filePaths = firstPath ? [firstPath] : [];
+                            }
+                        } else {
+                            // With -z name-status, Git may emit status and paths as separate NUL records.
+                            const status = record.toUpperCase();
+                            if (status.startsWith('R') || status.startsWith('C')) {
+                                const oldPath = nextRecordSupplier();
+                                const newPath = nextRecordSupplier();
+                                filePaths = [oldPath, newPath].filter((p) => typeof p === 'string' && p.length > 0);
+                            } else {
+                                const filePath = nextRecordSupplier();
+                                filePaths = filePath ? [filePath] : [];
+                            }
+                        }
+
                         if (filePaths.length === 0) {
                             return;
                         }
@@ -2663,12 +2658,17 @@ class LeakLockPanel {
 
                     gitLog.stdout.on('data', (chunk) => {
                         stdoutBuffer += chunk.toString();
-                        let newlineIndex = stdoutBuffer.indexOf('\n');
-                        while (newlineIndex !== -1) {
-                            const line = stdoutBuffer.slice(0, newlineIndex).replace(/\r$/, '');
-                            stdoutBuffer = stdoutBuffer.slice(newlineIndex + 1);
-                            processLine(line);
-                            newlineIndex = stdoutBuffer.indexOf('\n');
+                        const records = stdoutBuffer.split('\0');
+                        stdoutBuffer = records.pop() || '';
+                        for (let i = 0; i < records.length; i++) {
+                            const consumeNext = () => {
+                                if (i + 1 >= records.length) {
+                                    return '';
+                                }
+                                i += 1;
+                                return records[i];
+                            };
+                            processNameStatusRecord(records[i], consumeNext);
                         }
                     });
 
@@ -2682,7 +2682,7 @@ class LeakLockPanel {
 
                     gitLog.on('close', (code, signal) => {
                         if (stdoutBuffer) {
-                            processLine(stdoutBuffer.replace(/\r$/, ''));
+                            processNameStatusRecord(stdoutBuffer.replace(/\r$/, ''), () => '');
                             stdoutBuffer = '';
                         }
                         if (stoppedEarly) {

--- a/leakLockPanel.js
+++ b/leakLockPanel.js
@@ -2584,7 +2584,32 @@ class LeakLockPanel {
                     let stdoutBuffer = '';
                     let stderrBuffer = '';
                     let stoppedEarly = false;
+                    let timedOut = false;
+                    let settled = false;
                     const gitLog = spawn('git', gitArgs, { stdio: ['ignore', 'pipe', 'pipe'] });
+                    const timeoutMs = Math.max(1000, gitLogOptions.timeout || 20000);
+                    const timeoutHandle = setTimeout(() => {
+                        timedOut = true;
+                        gitLog.kill();
+                    }, timeoutMs);
+
+                    const settleResolve = () => {
+                        if (settled) {
+                            return;
+                        }
+                        settled = true;
+                        clearTimeout(timeoutHandle);
+                        resolve();
+                    };
+
+                    const settleReject = (error) => {
+                        if (settled) {
+                            return;
+                        }
+                        settled = true;
+                        clearTimeout(timeoutHandle);
+                        reject(error);
+                    };
 
                     const processLine = (rawLine) => {
                         if (findings.length >= maxTotalFindings) {
@@ -2652,7 +2677,7 @@ class LeakLockPanel {
                     });
 
                     gitLog.on('error', (error) => {
-                        reject(error);
+                        settleReject(error);
                     });
 
                     gitLog.on('close', (code, signal) => {
@@ -2661,15 +2686,19 @@ class LeakLockPanel {
                             stdoutBuffer = '';
                         }
                         if (stoppedEarly) {
-                            resolve();
+                            settleResolve();
+                            return;
+                        }
+                        if (timedOut) {
+                            settleReject(new Error(`git log filename history timed out after ${timeoutMs}ms`));
                             return;
                         }
                         if (code === 0) {
-                            resolve();
+                            settleResolve();
                             return;
                         }
                         const reason = signal ? `signal ${signal}` : `exit code ${code}`;
-                        reject(new Error(`git log filename history failed (${reason}): ${stderrBuffer.trim()}`));
+                        settleReject(new Error(`git log filename history failed (${reason}): ${stderrBuffer.trim()}`));
                     });
                 });
             }

--- a/leakLockPanel.js
+++ b/leakLockPanel.js
@@ -2481,6 +2481,7 @@ class LeakLockPanel {
                             longKeywords.push(normalized);
                         }
                     }
+                    const fileHistoryMatcherMap = new Map(fileHistoryKeywordMatchers.map((entry) => [entry.keyword, entry.matches]));
 
                     const runFileHistoryPass = async (passKeywords, options = {}) => {
                         if (!Array.isArray(passKeywords) || passKeywords.length === 0) {
@@ -2521,14 +2522,6 @@ class LeakLockPanel {
                             '.'
                         ], gitLogOptions);
 
-                        const matcherMap = new Map();
-                        for (const keyword of passKeywords) {
-                            const matcherEntry = fileHistoryKeywordMatchers.find((entry) => entry.keyword === keyword);
-                            if (matcherEntry) {
-                                matcherMap.set(keyword, matcherEntry.matches);
-                            }
-                        }
-
                         const lines = stdout.split('\n');
                         let currentCommit = null;
                         let currentDate = null;
@@ -2568,7 +2561,7 @@ class LeakLockPanel {
                                 if (existingCount >= keywordConfig.maxMatchesPerKeyword) {
                                     continue;
                                 }
-                                const matches = matcherMap.get(keyword);
+                                const matches = fileHistoryMatcherMap.get(keyword);
                                 if (!matches || !matches(patchLine)) {
                                     continue;
                                 }

--- a/leakLockSidebarProvider.js
+++ b/leakLockSidebarProvider.js
@@ -15,6 +15,7 @@ class LeakLockSidebarProvider {
         this._installProgress = null;
         this._workspaceGitRepo = null;
         this._showDependencyDetails = false;
+        this._showGitHistorySection = false;
     }
 
     resolveWebviewView(webviewView, context, _token) {
@@ -29,7 +30,7 @@ class LeakLockSidebarProvider {
 
         // Handle messages from the webview
         webviewView.webview.onDidReceiveMessage(
-            message => {
+            async message => {
                 switch (message.command) {
                     case 'installDependencies':
                         this._installDependencies();
@@ -61,6 +62,46 @@ class LeakLockSidebarProvider {
                             directory: this._selectedDirectory || this._workspaceGitRepo || null
                         });
                         break;
+                    case 'toggleGitHistorySection':
+                        this._showGitHistorySection = !this._showGitHistorySection;
+                        this._updateView();
+                        break;
+                    case 'updateGitHistorySetting': {
+                        const cfg = vscode.workspace.getConfiguration('leakLock');
+                        await cfg.update(
+                            `gitHistoryKeywordSearch.${message.key}`,
+                            message.value,
+                            vscode.ConfigurationTarget.Global
+                        );
+                        this._updateView();
+                        break;
+                    }
+                    case 'addGitHistoryKeyword': {
+                        const keyword = (message.keyword || '').trim();
+                        if (!keyword) break;
+                        const cfg = vscode.workspace.getConfiguration('leakLock');
+                        const current = cfg.get('gitHistoryKeywordSearch.keywords') || [];
+                        if (!current.includes(keyword)) {
+                            await cfg.update(
+                                'gitHistoryKeywordSearch.keywords',
+                                [...current, keyword],
+                                vscode.ConfigurationTarget.Global
+                            );
+                        }
+                        this._updateView();
+                        break;
+                    }
+                    case 'removeGitHistoryKeyword': {
+                        const cfg = vscode.workspace.getConfiguration('leakLock');
+                        const current = cfg.get('gitHistoryKeywordSearch.keywords') || [];
+                        await cfg.update(
+                            'gitHistoryKeywordSearch.keywords',
+                            current.filter(k => k !== message.keyword),
+                            vscode.ConfigurationTarget.Global
+                        );
+                        this._updateView();
+                        break;
+                    }
                 }
             },
             undefined,
@@ -259,12 +300,144 @@ class LeakLockSidebarProvider {
                     font-size: 11px;
                     margin-top: 5px;
                 }
+
+                .toggle-row {
+                    display: flex;
+                    align-items: center;
+                    justify-content: space-between;
+                    margin: 6px 0;
+                    font-size: 12px;
+                }
+
+                .toggle-btn {
+                    width: 36px;
+                    height: 18px;
+                    border-radius: 9px;
+                    border: none;
+                    cursor: pointer;
+                    position: relative;
+                    transition: background 0.2s;
+                    flex-shrink: 0;
+                }
+
+                .toggle-btn.on {
+                    background: var(--vscode-button-background);
+                }
+
+                .toggle-btn.off {
+                    background: var(--vscode-button-secondaryBackground);
+                }
+
+                .toggle-btn::after {
+                    content: '';
+                    position: absolute;
+                    top: 2px;
+                    width: 14px;
+                    height: 14px;
+                    border-radius: 50%;
+                    background: var(--vscode-button-foreground);
+                    transition: left 0.2s;
+                }
+
+                .toggle-btn.on::after { left: 20px; }
+                .toggle-btn.off::after { left: 2px; }
+
+                .keyword-list {
+                    margin: 6px 0;
+                    max-height: 120px;
+                    overflow-y: auto;
+                }
+
+                .keyword-item {
+                    display: flex;
+                    align-items: center;
+                    justify-content: space-between;
+                    padding: 2px 4px;
+                    margin: 2px 0;
+                    background: var(--vscode-textCodeBlock-background);
+                    border-radius: 3px;
+                    font-size: 11px;
+                    font-family: var(--vscode-editor-font-family);
+                }
+
+                .keyword-remove {
+                    background: none;
+                    border: none;
+                    color: var(--vscode-inputValidation-errorForeground);
+                    cursor: pointer;
+                    font-size: 13px;
+                    padding: 0 3px;
+                    line-height: 1;
+                }
+
+                .keyword-add-row {
+                    display: flex;
+                    gap: 4px;
+                    margin-top: 6px;
+                }
+
+                .keyword-input {
+                    flex: 1;
+                    background: var(--vscode-input-background);
+                    color: var(--vscode-input-foreground);
+                    border: 1px solid var(--vscode-input-border);
+                    border-radius: 3px;
+                    padding: 3px 6px;
+                    font-size: 11px;
+                    font-family: var(--vscode-editor-font-family);
+                    min-width: 0;
+                }
+
+                .keyword-add-btn {
+                    background: var(--vscode-button-background);
+                    color: var(--vscode-button-foreground);
+                    border: none;
+                    border-radius: 3px;
+                    padding: 3px 8px;
+                    cursor: pointer;
+                    font-size: 11px;
+                    white-space: nowrap;
+                }
+
+                .keyword-add-btn:hover {
+                    background: var(--vscode-button-hoverBackground);
+                }
+
+                .number-input {
+                    width: 60px;
+                    background: var(--vscode-input-background);
+                    color: var(--vscode-input-foreground);
+                    border: 1px solid var(--vscode-input-border);
+                    border-radius: 3px;
+                    padding: 3px 6px;
+                    font-size: 11px;
+                    text-align: right;
+                }
+
+                .section-toggle-header {
+                    display: flex;
+                    align-items: center;
+                    justify-content: space-between;
+                    cursor: pointer;
+                    margin: 0;
+                    padding: 0;
+                }
+
+                .section-toggle-header h3 {
+                    margin: 0;
+                }
+
+                .chevron {
+                    font-size: 10px;
+                    color: var(--vscode-descriptionForeground);
+                }
             </style>
         </head>
         <body>
             ${this._getDependenciesSection()}
             ${this._getDirectorySection()}
             ${this._getScanSection()}
+            ${this._getGitHistorySection()}
             ${this._getRemoveFilesSection()}
             
             <script>
@@ -297,6 +470,39 @@ class LeakLockSidebarProvider {
                 function openRemoveFiles() {
                     vscode.postMessage({ command: 'openRemoveFiles' });
                 }
+
+                function toggleGitHistorySection() {
+                    vscode.postMessage({ command: 'toggleGitHistorySection' });
+                }
+
+                function toggleGitHistorySetting(key, current) {
+                    vscode.postMessage({ command: 'updateGitHistorySetting', key, value: !current });
+                }
+
+                function updateMaxMatches(value) {
+                    const n = parseInt(value, 10);
+                    if (!isNaN(n) && n >= 1 && n <= 500) {
+                        vscode.postMessage({ command: 'updateGitHistorySetting', key: 'maxMatchesPerKeyword', value: n });
+                    }
+                }
+
+                function addKeyword() {
+                    const input = document.getElementById('keyword-input');
+                    const keyword = (input?.value || '').trim();
+                    if (!keyword) return;
+                    vscode.postMessage({ command: 'addGitHistoryKeyword', keyword });
+                    if (input) input.value = '';
+                }
+
+                function removeKeyword(keyword) {
+                    vscode.postMessage({ command: 'removeGitHistoryKeyword', keyword });
+                }
+
+                document.addEventListener('keydown', (e) => {
+                    if (e.key === 'Enter' && document.activeElement?.id === 'keyword-input') {
+                        addKeyword();
+                    }
+                });
             </script>
         </body>
         </html>`;
@@ -562,6 +768,81 @@ class LeakLockSidebarProvider {
                     ${buttonText}
                 </button>
                 ${!canScan ? '<div class="warning-text">Complete setup steps above first</div>' : scanInfo}
+            </div>
+        `;
+    }
+
+    _getGitHistorySection() {
+        const cfg = vscode.workspace.getConfiguration('leakLock');
+        const enabled = cfg.get('gitHistoryKeywordSearch.enabled', false);
+        const searchCommitMessages = cfg.get('gitHistoryKeywordSearch.searchCommitMessages', true);
+        const searchFileHistory = cfg.get('gitHistoryKeywordSearch.searchFileHistory', true);
+        const maxMatches = cfg.get('gitHistoryKeywordSearch.maxMatchesPerKeyword', 25);
+        const keywords = cfg.get('gitHistoryKeywordSearch.keywords', []);
+
+        const chevron = this._showGitHistorySection ? '▲' : '▼';
+        const enabledClass = enabled ? 'on' : 'off';
+        const commitClass = searchCommitMessages ? 'on' : 'off';
+        const fileHistClass = searchFileHistory ? 'on' : 'off';
+
+        const keywordItems = keywords.map(k =>
+            `<div class="keyword-item">
+                <span>${k}</span>
+                <button class="keyword-remove" onclick="removeKeyword(${JSON.stringify(k)})" title="Remove">✕</button>
+            </div>`
+        ).join('');
+
+        const expandedContent = this._showGitHistorySection ? `
+            <div style="margin-top: 12px;">
+                <div class="toggle-row">
+                    <span>Search commit messages</span>
+                    <button class="toggle-btn ${commitClass}"
+                        onclick="toggleGitHistorySetting('searchCommitMessages', ${searchCommitMessages})"
+                        title="${searchCommitMessages ? 'Enabled' : 'Disabled'}">
+                    </button>
+                </div>
+                <div class="toggle-row">
+                    <span>Search file history</span>
+                    <button class="toggle-btn ${fileHistClass}"
+                        onclick="toggleGitHistorySetting('searchFileHistory', ${searchFileHistory})"
+                        title="${searchFileHistory ? 'Enabled' : 'Disabled'}">
+                    </button>
+                </div>
+                <div class="toggle-row" style="margin-top: 8px;">
+                    <span>Max matches per keyword</span>
+                    <input class="number-input" type="number" min="1" max="500" value="${maxMatches}"
+                        onchange="updateMaxMatches(this.value)"
+                        onblur="updateMaxMatches(this.value)" />
+                </div>
+
+                <div style="margin-top: 10px; font-size: 11px; color: var(--vscode-descriptionForeground); margin-bottom: 4px;">
+                    Keywords (${keywords.length})
+                </div>
+                <div class="keyword-list">
+                    ${keywordItems || '<div style="font-size:11px;color:var(--vscode-descriptionForeground);padding:4px;">No keywords configured</div>'}
+                </div>
+                <div class="keyword-add-row">
+                    <input id="keyword-input" class="keyword-input" type="text" placeholder="Add keyword…" />
+                    <button class="keyword-add-btn" onclick="addKeyword()">Add</button>
+                </div>
+            </div>
+        ` : '';
+
+        return `
+            <div class="section">
+                <div class="section-toggle-header" onclick="toggleGitHistorySection()">
+                    <h3>🔎 Git History Search</h3>
+                    <span class="chevron">${chevron}</span>
+                </div>
+                <div class="toggle-row" style="margin-top: 10px;">
+                    <span style="font-weight: 600;">Enable git history scanning</span>
+                    <button class="toggle-btn ${enabledClass}"
+                        onclick="toggleGitHistorySetting('enabled', ${enabled})"
+                        title="${enabled ? 'Enabled — click to disable' : 'Disabled — click to enable'}">
+                    </button>
+                </div>
+                ${!enabled ? `<div style="font-size:10px;color:var(--vscode-descriptionForeground);margin-top:4px;">Scans commit messages and file history for configured keywords.</div>` : ''}
+                ${expandedContent}
             </div>
         `;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "leak-lock",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "leak-lock",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "dependencies": {
         "globals": "^15.15.0"
       },

--- a/package.json
+++ b/package.json
@@ -89,8 +89,8 @@
         },
         "leakLock.gitHistoryKeywordSearch.searchFileNames": {
           "type": "boolean",
-          "default": true,
-          "description": "When git-history text search is enabled, search historical file names."
+          "default": false,
+          "description": "When git-history text search is enabled, search historical file names (can increase scan time on large repositories)."
         },
         "leakLock.gitHistoryKeywordSearch.maxMatchesPerKeyword": {
           "type": "integer",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,13 @@
           "maximum": 500,
           "description": "Maximum number of keyword findings to collect per keyword and search mode."
         },
+        "leakLock.gitHistoryKeywordSearch.shortKeywordFileHistoryMaxCount": {
+          "type": "integer",
+          "default": 300,
+          "minimum": 100,
+          "maximum": 5000,
+          "description": "Maximum `git log --max-count` used for short keyword (<=3 chars) file-history scans. Increase for deeper history at higher runtime cost."
+        },
         "leakLock.gitHistoryKeywordSearch.keywords": {
           "type": "array",
           "default": [

--- a/package.json
+++ b/package.json
@@ -75,22 +75,22 @@
         "leakLock.gitHistoryKeywordSearch.enabled": {
           "type": "boolean",
           "default": false,
-          "description": "Enable attribution-policy keyword scanning in git history (commit messages and historical file content changes)."
+          "description": "Enable attribution-policy keyword scanning in git history (commit messages, historical file content changes, and historical file names)."
         },
         "leakLock.gitHistoryKeywordSearch.searchCommitMessages": {
           "type": "boolean",
           "default": true,
-          "description": "When keyword history scan is enabled, search commit messages."
+          "description": "When git-history keyword search is enabled, search commit messages."
         },
         "leakLock.gitHistoryKeywordSearch.searchFileHistory": {
           "type": "boolean",
           "default": true,
-          "description": "When git-history text search is enabled, search historical file content changes (supports arbitrary text terms)."
+          "description": "When git-history keyword search is enabled, search historical file content changes (supports arbitrary text terms)."
         },
         "leakLock.gitHistoryKeywordSearch.searchFileNames": {
           "type": "boolean",
           "default": false,
-          "description": "When git-history text search is enabled, search historical file names (can increase scan time on large repositories)."
+          "description": "When git-history keyword search is enabled, search historical file names (can increase scan time on large repositories)."
         },
         "leakLock.gitHistoryKeywordSearch.maxMatchesPerKeyword": {
           "type": "integer",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "leak-lock",
   "description": "Developer tools to help engineers stay cybersecure without interrupting their workflows",
   "icon": "media/icon.png",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/nikolareljin/leak-lock.git"
@@ -85,7 +85,12 @@
         "leakLock.gitHistoryKeywordSearch.searchFileHistory": {
           "type": "boolean",
           "default": true,
-          "description": "When keyword history scan is enabled, search historical file content changes."
+          "description": "When git-history text search is enabled, search historical file content changes (supports arbitrary text terms)."
+        },
+        "leakLock.gitHistoryKeywordSearch.searchFileNames": {
+          "type": "boolean",
+          "default": true,
+          "description": "When git-history text search is enabled, search historical file names."
         },
         "leakLock.gitHistoryKeywordSearch.maxMatchesPerKeyword": {
           "type": "integer",
@@ -121,7 +126,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Keywords to detect in git history commit messages and/or file history (defaults focus on agent attribution and sensitive credential terms)."
+          "description": "Search terms to detect in git history commit messages, file content history, and file names."
         }
       }
     },


### PR DESCRIPTION
## Summary
- add git-history filename search mode via leakLock.gitHistoryKeywordSearch.searchFileNames
- allow arbitrary text terms in file-history content matching (short terms no longer skipped)
- keep existing commit-message path labeling and update docs/settings for the expanded search scope
- bump version to 0.5.0 (minor release)

## Validation
- node --check leakLockPanel.js
