### PR TITLE
fix: git history keyword removal, plus dependency upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ jobs:
       # virtual display on Linux. node_modules is already present from the lint
       # step, which runs first.
       test_command: "sudo apt-get update && sudo apt-get install -y xvfb && xvfb-run -a -s '-screen 0 1024x768x24' npm test"
-      # No build step: this extension ships its sources directly (the package.json
-      # "build" script targets a src/ directory that does not exist).
-      build_command: ""
+      # The extension ships its sources directly, so there is nothing to compile
+      # (the package.json "build" script targets a src/ directory that does not
+      # exist). Packaging runs here anyway because `vsce package` is the only
+      # step that validates @types/vscode against engines.vscode, and until now
+      # it lived solely in publish.yml — which runs *after* a merge to main. A
+      # dependency bump that raises @types/vscode past engines.vscode therefore
+      # passed CI and broke publishing. This catches it on the pull request.
+      build_command: "npx --yes @vscode/vsce@latest package --no-dependencies -o /tmp/leak-lock-ci.vsix"

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -2,7 +2,7 @@ import { defineConfig } from '@vscode/test-cli';
 
 export default defineConfig({
 	files: 'test/**/*.test.js',
-	version: '1.96.0',
+	version: '1.125.0',
 	// Configure for CI environments
 	mocha: {
 		ui: 'tdd',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 ## 0.7.1
 ### Fixed
-- **Git History keyword removal never worked**: the ✕ next to a keyword did nothing at all. Each remove button was rendered as `onclick="removeKeyword(${JSON.stringify(k)})"`, which places a double-quoted JavaScript string literal inside a double-quoted HTML attribute — the attribute ended at the first inner quote, so the handler the browser actually parsed was the fragment `removeKeyword(` and every click raised a syntax error in the webview instead of posting a message. The extension-side `removeGitHistoryKeyword` handler was never reached, which is why the keyword list never changed. The button now carries its keyword in a `data-keyword` attribute read by a delegated click listener, so no user input is interpolated into JavaScript source. Adding a keyword was never affected, because `addKeyword()` takes no arguments.
-- **Keywords are HTML-escaped in the sidebar**: keyword text is user input and was interpolated raw into both the visible label and the button attribute. A keyword containing `<`, `>`, `&` or a quote corrupted the rendered list, and one containing markup such as `<img onerror=…>` executed inside the sidebar webview. Both interpolation points are now escaped.
-- **`removeGitHistoryKeyword` message handling**: the handler declared a trimmed `keyword` variable but filtered against the raw `message.keyword`, so even once a message arrived the filter would not have matched. It now uses the trimmed value consistently, ignores empty input, and no longer emits leftover debug logging.
+- **Git History keyword removal never worked**: the ✕ next to a keyword did nothing. The keyword was quoted into an inline `onclick`, which broke the HTML attribute and made every click a syntax error, so the remove message was never sent. The button now passes the keyword via a `data-keyword` attribute and a delegated click listener.
+- **Keywords are HTML-escaped in the sidebar**: a keyword containing `<`, `>`, `&` or a quote corrupted the list, and one containing markup ran in the sidebar webview.
 
 ## 0.7.0
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.7.1
+### Fixed
+- **Git History keyword removal never worked**: the `removeGitHistoryKeyword` handler declared a trimmed `keyword` variable but then filtered against the raw `message.keyword`, so the filter never matched and the keyword list was always written back unchanged. The fix uses the trimmed variable consistently.
+
 ## 0.7.0
 ### Added
 - **Multiple Detection Engines**: Leak Lock no longer depends on a single scanner. **Gitleaks** (MIT, actively maintained, no Docker or JVM required), **TruffleHog** (live credential verification) and **Nosey Parker** (legacy, archived upstream) are **all enabled by default** and run together, their findings merged into one attributed list. A missing engine binary disables that engine, never the whole scan, and is reported in the coverage panel so an engine you have not installed is visible rather than silently absent. Enabling TruffleHog makes no network call on its own — verification is the separate `leakLock.trufflehog.verify` setting, off by default. Configure with `leakLock.scan.engines`. See [docs/SCANNING_ENGINES.md](docs/SCANNING_ENGINES.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 - **Git History keyword removal never worked**: the ✕ next to a keyword did nothing. The keyword was quoted into an inline `onclick`, which broke the HTML attribute and made every click a syntax error, so the remove message was never sent. The button now passes the keyword via a `data-keyword` attribute and a delegated click listener.
 - **Keyword list keeps its place after an edit**: the sidebar re-renders on every add or remove, which dropped the list back to the first keyword. Removing now holds the scroll position and focuses the keyword that took the freed slot; adding scrolls to the new entry and returns focus to the input.
 - **Keywords are HTML-escaped in the sidebar**: a keyword containing `<`, `>`, `&` or a quote corrupted the list, and one containing markup ran in the sidebar webview.
+- **Remove Files: a path with an apostrophe killed its Remove button**: the path was quoted into an inline `onclick`, so `John's notes.txt` produced a syntax error instead of a message — the same failure as the keyword ✕, on another surface. It now uses a `data-remove-target` attribute and a delegated listener.
 
 ### Changed
 - **Minimum VS Code is now 1.125.0** (was 1.96.0): `engines.vscode`, `@types/vscode` and the test target move together, because `vsce package` refuses a `@types/vscode` newer than `engines.vscode`. Also picks up `@types/node` 26.1.2 and `globals` 17.9.0.
+- **One HTML-escaping implementation**: the panel and the sidebar each carried their own `escapeHtml`, and the copies had already drifted. Both now use `html-escape.js`, so a fix on one surface reaches the other. Icon-only remove buttons also gained accessible names.
 - **CI packages the extension**: `vsce package` is the only step that checks `@types/vscode` against `engines.vscode`, and it ran only in `publish.yml` — after merge. It now runs on pull requests, where a dependency bump that breaks packaging is still cheap to fix.
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 - **Keyword list keeps its place after an edit**: the sidebar re-renders on every add or remove, which dropped the list back to the first keyword. Removing now holds the scroll position and focuses the keyword that took the freed slot; adding scrolls to the new entry and returns focus to the input.
 - **Keywords are HTML-escaped in the sidebar**: a keyword containing `<`, `>`, `&` or a quote corrupted the list, and one containing markup ran in the sidebar webview.
 
+### Changed
+- **Minimum VS Code is now 1.125.0** (was 1.96.0): `engines.vscode`, `@types/vscode` and the test target move together, because `vsce package` refuses a `@types/vscode` newer than `engines.vscode`. Also picks up `@types/node` 26.1.2 and `globals` 17.9.0.
+- **CI packages the extension**: `vsce package` is the only step that checks `@types/vscode` against `engines.vscode`, and it ran only in `publish.yml` — after merge. It now runs on pull requests, where a dependency bump that breaks packaging is still cheap to fix.
+
+### Security
+- **brace-expansion DoS (GHSA-rgw5-rvv9-x895)**: the advisory defeats the mitigation the previous pin relied on, and the pin was scoped to mocha, leaving `@vscode/test-cli`'s own branch uncovered. A top-level override on 5.0.9 clears all four findings.
+
 ## 0.7.0
 ### Added
 - **Multiple Detection Engines**: Leak Lock no longer depends on a single scanner. **Gitleaks** (MIT, actively maintained, no Docker or JVM required), **TruffleHog** (live credential verification) and **Nosey Parker** (legacy, archived upstream) are **all enabled by default** and run together, their findings merged into one attributed list. A missing engine binary disables that engine, never the whole scan, and is reported in the coverage panel so an engine you have not installed is visible rather than silently absent. Enabling TruffleHog makes no network call on its own — verification is the separate `leakLock.trufflehog.verify` setting, off by default. Configure with `leakLock.scan.engines`. See [docs/SCANNING_ENGINES.md](docs/SCANNING_ENGINES.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 0.7.1
 ### Fixed
-- **Git History keyword removal never worked**: the `removeGitHistoryKeyword` handler declared a trimmed `keyword` variable but then filtered against the raw `message.keyword`, so the filter never matched and the keyword list was always written back unchanged. The fix uses the trimmed variable consistently.
+- **Git History keyword removal never worked**: the ✕ next to a keyword did nothing at all. Each remove button was rendered as `onclick="removeKeyword(${JSON.stringify(k)})"`, which places a double-quoted JavaScript string literal inside a double-quoted HTML attribute — the attribute ended at the first inner quote, so the handler the browser actually parsed was the fragment `removeKeyword(` and every click raised a syntax error in the webview instead of posting a message. The extension-side `removeGitHistoryKeyword` handler was never reached, which is why the keyword list never changed. The button now carries its keyword in a `data-keyword` attribute read by a delegated click listener, so no user input is interpolated into JavaScript source. Adding a keyword was never affected, because `addKeyword()` takes no arguments.
+- **Keywords are HTML-escaped in the sidebar**: keyword text is user input and was interpolated raw into both the visible label and the button attribute. A keyword containing `<`, `>`, `&` or a quote corrupted the rendered list, and one containing markup such as `<img onerror=…>` executed inside the sidebar webview. Both interpolation points are now escaped.
+- **`removeGitHistoryKeyword` message handling**: the handler declared a trimmed `keyword` variable but filtered against the raw `message.keyword`, so even once a message arrived the filter would not have matched. It now uses the trimmed value consistently, ignores empty input, and no longer emits leftover debug logging.
 
 ## 0.7.0
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.7.1
 ### Fixed
 - **Git History keyword removal never worked**: the ✕ next to a keyword did nothing. The keyword was quoted into an inline `onclick`, which broke the HTML attribute and made every click a syntax error, so the remove message was never sent. The button now passes the keyword via a `data-keyword` attribute and a delegated click listener.
+- **Keyword list keeps its place after an edit**: the sidebar re-renders on every add or remove, which dropped the list back to the first keyword. Removing now holds the scroll position and focuses the keyword that took the freed slot; adding scrolls to the new entry and returns focus to the input.
 - **Keywords are HTML-escaped in the sidebar**: a keyword containing `<`, `>`, `&` or a quote corrupted the list, and one containing markup ran in the sidebar webview.
 
 ## 0.7.0

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 **Secure your code repositories by detecting and removing sensitive information from git history**
 
 [![Version](https://img.shields.io/badge/version-0.7.0-blue.svg)](package.json)
-[![VS Code](https://img.shields.io/badge/VS%20Code-1.96.0+-brightgreen.svg)](https://code.visualstudio.com/)
+[![VS Code](https://img.shields.io/badge/VS%20Code-1.125.0+-brightgreen.svg)](https://code.visualstudio.com/)
 
 [🌐 Website](https://nikolareljin.github.io/leak-lock/) • [📖 Documentation](#documentation) • [🚀 Quick Start](#quick-start) • [📸 Screenshots](#screenshots) • [🛠️ Development](#development)
 
@@ -323,7 +323,7 @@ See also:
 
 ### **Prerequisites**
 - Node.js 22.13.0+
-- VS Code 1.96.0+
+- VS Code 1.125.0+
 - Docker (for testing scanning functionality)
 
 ### **Setup**

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -15,7 +15,7 @@ The GitHub Actions workflow automatically runs tests in a headless environment u
 - Ubuntu latest
 - Node.js 22.13.0 or newer
 - Xvfb (X Virtual Framebuffer) for headless display
-- VS Code 1.96.0
+- VS Code 1.125.0
 
 ### Test Files
 - `test/extension.test.js` - Main extension tests
@@ -25,7 +25,7 @@ The GitHub Actions workflow automatically runs tests in a headless environment u
 ### Configuration Details
 
 The `.vscode-test.mjs` file configures:
-- VS Code version: 1.96.0
+- VS Code version: 1.125.0
 - Test files pattern: `test/**/*.test.js`
 - Mocha UI: TDD style
 - Timeout: 20 seconds

--- a/html-escape.js
+++ b/html-escape.js
@@ -1,0 +1,20 @@
+// Shared HTML escaping for the webviews.
+//
+// Both the panel and the sidebar render user-controlled strings — scan results,
+// file paths, keywords — into webview HTML, and each had grown its own copy of
+// this. The copies had already drifted (one coerced non-strings, the other did
+// not), which is exactly how an escaping bug gets reintroduced on one surface
+// after being fixed on the other. One implementation, used by both.
+function escapeHtml(unsafe) {
+    if (typeof unsafe !== 'string') {
+        return String(unsafe);
+    }
+    return unsafe
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+}
+
+module.exports = { escapeHtml };

--- a/leakLockPanel.js
+++ b/leakLockPanel.js
@@ -11,6 +11,8 @@ const scanEngineConfig = require('./scan-engine-config');
 const scanEngines = require('./scan-engines');
 const redactionRules = require('./redaction-rules');
 const hostCapacity = require('./host-capacity');
+// Shared with leakLockSidebarProvider.js so the two webviews escape identically.
+const { escapeHtml } = require('./html-escape');
 
 // Configuration constants
 const MAX_PATH_LENGTH = 4096; // Maximum allowed path length to prevent DoS attacks
@@ -207,24 +209,6 @@ function parseContainingBranches(stdout) {
             !name.includes('HEAD detached') &&
             !REMOTE_HEAD_FILTER_PATTERN.test(name)
         );
-}
-
-// HTML escaping function to prevent XSS
-function escapeHtml(unsafe) {
-    if (typeof unsafe !== 'string') {
-        return String(unsafe);
-    }
-    return unsafe
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;")
-        .replace(/"/g, "&quot;")
-        .replace(/'/g, "&#039;");
-}
-
-// JSON escaping for data attributes
-function escapeJsonAttribute(obj) {
-    return escapeHtml(JSON.stringify(obj));
 }
 
 // Get platform-appropriate sensitive directories
@@ -1750,7 +1734,9 @@ class LeakLockPanel {
                 ${targets.map(t => `<li style="margin: 4px 0;">
                     <code>${escapeHtml(t.path)}</code>
                     <span style=\"background: var(--vscode-button-secondaryBackground); color: var(--vscode-button-secondaryForeground); padding: 0 6px; border-radius: 10px; font-size: 0.8em;\">${t.type}</span>
-                    <button class="button" style="margin-left: 8px; padding: 2px 8px;" onclick="removeTarget('${escapeHtml(t.path)}')">Remove</button>
+                    <button class="button" style="margin-left: 8px; padding: 2px 8px;"
+                        data-remove-target="${escapeHtml(t.path)}"
+                        aria-label="Remove ${escapeHtml(t.path)} from the removal list">Remove</button>
                 </li>`).join('')}
             </ul>
         ` : '<div style="color: var(--vscode-descriptionForeground);">No files or directories selected.</div>';
@@ -1888,7 +1874,17 @@ class LeakLockPanel {
                     const vscode = acquireVsCodeApi();
                     // Repo selection is managed from the sidebar; no selection here
                     function selectTargets(kind) { vscode.postMessage({ command: 'removeFiles.selectTargets', kind }); }
-                    function removeTarget(path) { vscode.postMessage({ command: 'removeFiles.removeTarget', path }); }
+                    // A target path is user-controlled and may contain a quote, which
+                    // would close an inline onclick string literal early and leave the
+                    // button dead. The path rides in a data attribute instead, read by
+                    // a delegated listener, so nothing is interpolated into JS source.
+                    document.addEventListener('click', (e) => {
+                        const btn = e.target instanceof Element
+                            ? e.target.closest('[data-remove-target]')
+                            : null;
+                        if (!btn) return;
+                        vscode.postMessage({ command: 'removeFiles.removeTarget', path: btn.dataset.removeTarget });
+                    });
                     function clearTargets() { vscode.postMessage({ command: 'removeFiles.clearTargets' }); }
                     function prepareCommand() { vscode.postMessage({ command: 'removeFiles.prepare' }); }
                     function setCombineMode(mode) { vscode.postMessage({ command: 'removeFiles.setCombineMode', mode }); }

--- a/leakLockSidebarProvider.js
+++ b/leakLockSidebarProvider.js
@@ -6,17 +6,10 @@ const fs = require('fs');
 // The pinned Nosey Parker image. Checking or pulling `:latest` here while the scanner
 // runs the pinned tag meant these two disagreed about which image mattered.
 const scanEngineConfig = require('./scan-engine-config');
-
-// Keywords are user-supplied and land in both element text and an attribute value,
-// so they must be escaped before interpolation into the webview HTML.
-function escapeHtml(value) {
-    return String(value)
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#39;');
-}
+// Keywords are user-supplied and land in both element text and attribute values,
+// so they must be escaped before interpolation into the webview HTML. Shared with
+// leakLockPanel.js so both webviews escape identically.
+const { escapeHtml } = require('./html-escape');
 
 class LeakLockSidebarProvider {
     constructor(extensionUri) {
@@ -886,7 +879,8 @@ class LeakLockSidebarProvider {
         const keywordItems = keywords.map(k =>
             `<div class="keyword-item">
                 <span>${escapeHtml(k)}</span>
-                <button class="keyword-remove" data-keyword="${escapeHtml(k)}" title="Remove">✕</button>
+                <button class="keyword-remove" data-keyword="${escapeHtml(k)}"
+                    aria-label="Remove keyword ${escapeHtml(k)}" title="Remove keyword ${escapeHtml(k)}">✕</button>
             </div>`
         ).join('');
 

--- a/leakLockSidebarProvider.js
+++ b/leakLockSidebarProvider.js
@@ -7,6 +7,17 @@ const fs = require('fs');
 // runs the pinned tag meant these two disagreed about which image mattered.
 const scanEngineConfig = require('./scan-engine-config');
 
+// Keywords are user-supplied and land in both element text and an attribute value,
+// so they must be escaped before interpolation into the webview HTML.
+function escapeHtml(value) {
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
 class LeakLockSidebarProvider {
     constructor(extensionUri) {
         this._extensionUri = extensionUri;
@@ -512,9 +523,19 @@ class LeakLockSidebarProvider {
                     if (input) input.value = '';
                 }
 
-                function removeKeyword(keyword) {
-                    vscode.postMessage({ command: 'removeGitHistoryKeyword', keyword });
-                }
+                // Delegated: the keyword list is re-rendered on every _updateView(),
+                // and passing the keyword through a data attribute avoids quoting it
+                // into an inline onclick.
+                document.addEventListener('click', (e) => {
+                    const btn = e.target instanceof Element
+                        ? e.target.closest('.keyword-remove')
+                        : null;
+                    if (!btn) return;
+                    vscode.postMessage({
+                        command: 'removeGitHistoryKeyword',
+                        keyword: btn.dataset.keyword
+                    });
+                });
 
                 document.addEventListener('keydown', (e) => {
                     if (e.key === 'Enter' && document.activeElement?.id === 'keyword-input') {
@@ -809,8 +830,8 @@ class LeakLockSidebarProvider {
 
         const keywordItems = keywords.map(k =>
             `<div class="keyword-item">
-                <span>${k}</span>
-                <button class="keyword-remove" onclick="removeKeyword(${JSON.stringify(k)})" title="Remove">✕</button>
+                <span>${escapeHtml(k)}</span>
+                <button class="keyword-remove" data-keyword="${escapeHtml(k)}" title="Remove">✕</button>
             </div>`
         ).join('');
 

--- a/leakLockSidebarProvider.js
+++ b/leakLockSidebarProvider.js
@@ -395,6 +395,12 @@ class LeakLockSidebarProvider {
                     line-height: 1;
                 }
 
+                .keyword-remove:focus-visible {
+                    outline: 1px solid var(--vscode-focusBorder);
+                    outline-offset: 1px;
+                    border-radius: 2px;
+                }
+
                 .keyword-add-row {
                     display: flex;
                     gap: 4px;
@@ -515,10 +521,55 @@ class LeakLockSidebarProvider {
                     }
                 }
 
+                // Every keyword edit round-trips through the extension and comes back as
+                // _updateView(), which replaces the whole document — scroll position and
+                // focus do not survive that. vscode.setState() does, so an edit is flagged
+                // before the message goes out and the next document restores the view.
+                function markKeywordEdit(edit) {
+                    const list = document.querySelector('.keyword-list');
+                    vscode.setState({
+                        ...(vscode.getState() || {}),
+                        keywordEdit: { ...edit, scrollTop: list ? list.scrollTop : 0 }
+                    });
+                }
+
+                function restoreKeywordFocus() {
+                    const state = vscode.getState() || {};
+                    const edit = state.keywordEdit;
+                    if (!edit) return;
+                    vscode.setState({ ...state, keywordEdit: null });
+
+                    const list = document.querySelector('.keyword-list');
+                    const input = document.getElementById('keyword-input');
+
+                    // A removal leaves the list where it was: the item that shifted into
+                    // the freed slot takes focus, so removing a run of keywords from the
+                    // middle does not throw the list back to the top or the bottom.
+                    if (edit.type === 'remove') {
+                        if (list) list.scrollTop = edit.scrollTop;
+                        const buttons = document.querySelectorAll('.keyword-remove');
+                        if (buttons.length) {
+                            const target = buttons[Math.min(edit.index, buttons.length - 1)];
+                            target.focus({ preventScroll: true });
+                            target.scrollIntoView({ block: 'nearest' });
+                            return;
+                        }
+                    } else if (list) {
+                        // Keywords are appended, so an addition lands at the end.
+                        list.scrollTop = list.scrollHeight;
+                    }
+
+                    if (input) {
+                        input.focus();
+                        input.scrollIntoView({ block: 'nearest' });
+                    }
+                }
+
                 function addKeyword() {
                     const input = document.getElementById('keyword-input');
                     const keyword = (input?.value || '').trim();
                     if (!keyword) return;
+                    markKeywordEdit({ type: 'add' });
                     vscode.postMessage({ command: 'addGitHistoryKeyword', keyword });
                     if (input) input.value = '';
                 }
@@ -531,6 +582,8 @@ class LeakLockSidebarProvider {
                         ? e.target.closest('.keyword-remove')
                         : null;
                     if (!btn) return;
+                    const buttons = Array.from(document.querySelectorAll('.keyword-remove'));
+                    markKeywordEdit({ type: 'remove', index: buttons.indexOf(btn) });
                     vscode.postMessage({
                         command: 'removeGitHistoryKeyword',
                         keyword: btn.dataset.keyword
@@ -542,6 +595,8 @@ class LeakLockSidebarProvider {
                         addKeyword();
                     }
                 });
+
+                restoreKeywordFocus();
             </script>
         </body>
         </html>`;

--- a/leakLockSidebarProvider.js
+++ b/leakLockSidebarProvider.js
@@ -104,11 +104,13 @@ class LeakLockSidebarProvider {
                         break;
                     }
                     case 'removeGitHistoryKeyword': {
+                        const keyword = (message.keyword || '').trim();
+                        if (!keyword) break;
                         const cfg = vscode.workspace.getConfiguration('leakLock');
                         const current = cfg.get('gitHistoryKeywordSearch.keywords') || [];
                         await cfg.update(
                             'gitHistoryKeywordSearch.keywords',
-                            current.filter(k => k !== message.keyword),
+                            current.filter(k => k !== keyword),
                             vscode.ConfigurationTarget.Global
                         );
                         this._updateView();
@@ -541,17 +543,17 @@ class LeakLockSidebarProvider {
                 </div>
             `;
         }
-        
+
         // Show detailed dependency information when not all are met or installing
         const installButtonText = this._isInstalling ? 'Installing...' : 'Install Dependencies';
         const showSpinner = this._isInstalling;
-        
+
         // Get status for each dependency
         const dockerStatus = this._dependencyStatus?.docker?.installed ? '✅' : '❌';
         const noseyparkerStatus = this._dependencyStatus?.noseyparker?.installed ? '✅' : '❌';
         const javaStatus = this._dependencyStatus?.java?.installed ? '✅' : '⚠️';
         const bfgStatus = this._dependencyStatus?.bfg?.installed ? '✅' : '⚠️';
-        
+
         return `
             <div class="section">
                 <h3>🔧 Dependencies Setup</h3>
@@ -719,14 +721,14 @@ class LeakLockSidebarProvider {
     _getDirectorySection() {
         const hasDirectory = this._selectedDirectory !== null;
         const isGitRepo = this._workspaceGitRepo && this._selectedDirectory === this._workspaceGitRepo;
-        
+
         let directoryDisplay = '';
         let statusInfo = '';
-        
+
         if (hasDirectory) {
             // Show the selected path
             directoryDisplay = `<div class="selected-path">${this._selectedDirectory}</div>`;
-            
+
             // Add status information
             if (isGitRepo) {
                 statusInfo = '<div style="color: var(--vscode-gitDecoration-addedResourceForeground); font-size: 11px; margin-top: 5px;">📦 Git repository detected</div>';
@@ -753,7 +755,7 @@ class LeakLockSidebarProvider {
                 directoryDisplay = '<div class="warning-text">No directory selected</div>';
             }
         }
-            
+
         return `
             <div class="section">
                 <h3>📁 Target Directory</h3>
@@ -770,7 +772,7 @@ class LeakLockSidebarProvider {
         const canScan = this._dependenciesInstalled && this._selectedDirectory;
         const buttonText = canScan ? '🔍 Start Scan' : '🔍 Setup Required';
         const isGitRepo = this._workspaceGitRepo && this._selectedDirectory === this._workspaceGitRepo;
-        
+
         let scanInfo = '';
         if (canScan) {
             const directoryName = path.basename(this._selectedDirectory);
@@ -780,7 +782,7 @@ class LeakLockSidebarProvider {
                 scanInfo = `<div style="color: var(--vscode-descriptionForeground); font-size: 11px; margin-top: 5px;">📁 Will scan directory: <strong>${directoryName}</strong></div>`;
             }
         }
-        
+
         return `
             <div class="section">
                 <h3>🚀 Scan Control</h3>
@@ -894,20 +896,20 @@ class LeakLockSidebarProvider {
         const { exec } = require('child_process');
         const util = require('util');
         const execAsync = util.promisify(exec);
-        
+
         this._dependencyStatus = {
             docker: { installed: false, version: null, error: null },
             noseyparker: { installed: false, error: null },
             java: { installed: false, version: null, error: null },
             bfg: { installed: false, path: null, error: null }
         };
-        
+
         // Check Docker
         try {
             const dockerVersion = await execAsync('docker --version');
             this._dependencyStatus.docker.installed = true;
             this._dependencyStatus.docker.version = dockerVersion.stdout.trim();
-            
+
             // Check if Docker daemon is running
             try {
                 await execAsync('docker info');
@@ -918,7 +920,7 @@ class LeakLockSidebarProvider {
         } catch (error) {
             this._dependencyStatus.docker.error = 'Docker not installed or not in PATH';
         }
-        
+
         // Check Nosey Parker image
         try {
             await execAsync(`docker images ${scanEngineConfig.NOSEYPARKER_IMAGE} --format "table {{.Repository}}"`);
@@ -926,7 +928,7 @@ class LeakLockSidebarProvider {
         } catch (error) {
             this._dependencyStatus.noseyparker.error = 'Nosey Parker Docker image not available';
         }
-        
+
         // Check Java
         try {
             const javaVersion = await execAsync('java -version 2>&1');
@@ -935,7 +937,7 @@ class LeakLockSidebarProvider {
         } catch (error) {
             this._dependencyStatus.java.error = 'Java not installed or not in PATH';
         }
-        
+
         // Check BFG tool
         const bfgPath = path.join(this._extensionUri.fsPath, 'bfg.jar');
         if (fs.existsSync(bfgPath)) {
@@ -944,11 +946,11 @@ class LeakLockSidebarProvider {
         } else {
             this._dependencyStatus.bfg.error = 'BFG tool not downloaded';
         }
-        
+
         // Overall status - all core dependencies must be met
-        this._dependenciesInstalled = this._dependencyStatus.docker.installed && 
-                                      this._dependencyStatus.noseyparker.installed;
-        
+        this._dependenciesInstalled = this._dependencyStatus.docker.installed &&
+            this._dependencyStatus.noseyparker.installed;
+
         this._updateView();
     }
 
@@ -964,7 +966,7 @@ class LeakLockSidebarProvider {
             for (const folder of workspaceFolders) {
                 const folderPath = folder.uri.fsPath;
                 const gitPath = path.join(folderPath, '.git');
-                
+
                 try {
                     // Check if .git directory or file exists
                     if (fs.existsSync(gitPath)) {
@@ -972,12 +974,12 @@ class LeakLockSidebarProvider {
                         if (stat.isDirectory() || stat.isFile()) {
                             // This is a git repository
                             this._workspaceGitRepo = folderPath;
-                            
+
                             // Auto-select if no directory is currently selected
                             if (!this._selectedDirectory) {
                                 this._selectedDirectory = folderPath;
                             }
-                            
+
                             this._updateView();
                             return;
                         }
@@ -987,13 +989,13 @@ class LeakLockSidebarProvider {
                     continue;
                 }
             }
-            
+
             // If no git repo found but workspace exists, offer first workspace folder
             if (!this._selectedDirectory && workspaceFolders.length > 0) {
                 this._selectedDirectory = workspaceFolders[0].uri.fsPath;
                 this._updateView();
             }
-            
+
         } catch (error) {
             console.warn('Failed to detect git repository:', error.message);
         }
@@ -1011,12 +1013,12 @@ class LeakLockSidebarProvider {
                 cancellable: false
             }, async (progress) => {
                 progress.report({ increment: 20, message: "Checking Docker..." });
-                
+
                 // Check if Docker is available
                 const { exec } = require('child_process');
                 const util = require('util');
                 const execAsync = util.promisify(exec);
-                
+
                 try {
                     await execAsync('docker --version');
                 } catch (error) {
@@ -1024,12 +1026,12 @@ class LeakLockSidebarProvider {
                 }
 
                 progress.report({ increment: 30, message: "Pulling Nosey Parker image..." });
-                
+
                 // Pull the Nosey Parker Docker image
                 await execAsync(`docker pull ${scanEngineConfig.NOSEYPARKER_IMAGE}`, { timeout: 300000 });
-                
+
                 progress.report({ increment: 30, message: "Downloading BFG tool..." });
-                
+
                 // Download BFG tool
                 try {
                     const bfgPath = path.join(this._extensionUri.fsPath, 'bfg.jar');
@@ -1039,9 +1041,9 @@ class LeakLockSidebarProvider {
                     console.warn('Failed to download BFG tool:', bfgError.message);
                     // Continue without BFG - it's optional
                 }
-                
+
                 progress.report({ increment: 20, message: "Verifying installation..." });
-                
+
                 // Recheck all dependencies
                 await this._checkDependencies();
             });
@@ -1083,10 +1085,10 @@ class LeakLockSidebarProvider {
             vscode.commands.executeCommand('leak-lock.updateRemoveFilesRepo', {
                 directory: this._selectedDirectory
             });
-            
+
             // Show confirmation message
             const isGitRepo = this._workspaceGitRepo === result[0].fsPath;
-            const message = isGitRepo 
+            const message = isGitRepo
                 ? `Selected git repository: ${path.basename(result[0].fsPath)}`
                 : `Selected directory: ${path.basename(result[0].fsPath)}`;
             vscode.window.showInformationMessage(message);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,24 @@
 {
   "name": "leak-lock",
-  "version": "0.6.3",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "leak-lock",
-      "version": "0.6.3",
+      "version": "0.7.1",
       "devDependencies": {
         "@types/mocha": "^10.0.10",
-        "@types/node": "^22.20.1",
-        "@types/vscode": "1.96.0",
+        "@types/node": "^26.1.2",
+        "@types/vscode": "1.125.0",
         "@vscode/test-cli": "^0.0.15",
         "@vscode/test-electron": "^3.1.0",
         "eslint": "^10.8.0",
-        "globals": "^17.8.0"
+        "globals": "^17.9.0"
       },
       "engines": {
         "node": ">=22.13.0",
-        "vscode": "^1.96.0"
+        "vscode": "^1.125.0"
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -333,19 +333,19 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.20.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
-      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/vscode": {
-      "version": "1.96.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.96.0.tgz",
-      "integrity": "sha512-qvZbSZo+K4ZYmmDuaodMbAa67Pl6VDQzLKFka6rq+3WUTY4Kro7Bwoi0CuZLO/wema0ygcmpwow7zZfPJTs5jg==",
+      "version": "1.125.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
+      "integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
       "dev": true,
       "license": "MIT"
     },
@@ -485,9 +485,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1187,9 +1187,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.8.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.8.0.tgz",
-      "integrity": "sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==",
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
+      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1621,9 +1621,9 @@
       }
     },
     "node_modules/mocha": {
-      "version": "11.7.6",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.6.tgz",
-      "integrity": "sha512-nS9xOGbw2I3cjCpxwZAEJ9xK9lmJ08vEkQvLtz4du9ZrF9UrjRpeJGiIgl2Z+Qs++pmB4ecDe48Fwsh+j+j7xA==",
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.8.0.tgz",
+      "integrity": "sha512-VyCeUdGN3A9lmCTTgG4yuvY9ixxaDk+xt2R/7/+1AP6EqNG+G9OKkzBwhVtVYoNX8YsxNSgAl8mOv3IAeOpFbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2374,9 +2374,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "leak-lock",
   "description": "Developer tools to help engineers stay cybersecure without interrupting their workflows",
   "icon": "media/icon.png",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/nikolareljin/leak-lock.git"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/nikolareljin/leak-lock.git"
   },
   "engines": {
-    "vscode": "^1.96.0",
+    "vscode": "^1.125.0",
     "node": ">=22.13.0"
   },
   "categories": [
@@ -283,18 +283,18 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",
-    "@types/node": "^22.20.1",
-    "@types/vscode": "1.96.0",
+    "@types/node": "^26.1.2",
+    "@types/vscode": "1.125.0",
     "@vscode/test-cli": "^0.0.15",
     "@vscode/test-electron": "^3.1.0",
     "eslint": "^10.8.0",
-    "globals": "^17.8.0"
+    "globals": "^17.9.0"
   },
   "overrides": {
+    "brace-expansion": "5.0.9",
     "mocha": {
       "serialize-javascript": "7.0.5",
       "diff": "8.0.3",
-      "brace-expansion": "5.0.8",
       "glob": "10.5.0",
       "minimatch": "9.0.9"
     }

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -3404,3 +3404,85 @@ suite('The scan records the fetch it performed', () => {
 			'a scan that fetched must record that it fetched');
 	});
 });
+
+suite('User text never reaches a webview event handler', () => {
+	const fs = require('fs');
+	const path = require('path');
+
+	// Both dead buttons had the same shape: a user-controlled string interpolated
+	// into an inline handler inside a quoted HTML attribute. A quote in the value
+	// closed the attribute (or the JS string literal) early, so the parsed handler
+	// was a fragment and every click raised a syntax error in the webview. The
+	// button looked normal and did nothing.
+
+	test('a keyword containing a quote still renders a working remove button', () => {
+		const { LeakLockSidebarProvider } = require('../leakLockSidebarProvider');
+		const provider = new LeakLockSidebarProvider(vscode.Uri.file(__dirname));
+		provider._showGitHistorySection = true;
+
+		const originalGet = vscode.workspace.getConfiguration;
+		vscode.workspace.getConfiguration = () => ({
+			get: (key, fallback) => (key === 'gitHistoryKeywordSearch.keywords' ? ["it's"] : fallback)
+		});
+		let html;
+		try {
+			html = provider._getGitHistorySection();
+		} finally {
+			vscode.workspace.getConfiguration = originalGet;
+		}
+
+		assert.ok(
+			html.includes('data-keyword="it&#039;s"'),
+			'the keyword must travel in a data attribute, escaped'
+		);
+		assert.ok(
+			!/removeKeyword\(/.test(html),
+			'no keyword may be interpolated into an inline handler'
+		);
+		assert.ok(
+			html.includes('aria-label="Remove keyword it&#039;s"'),
+			'an icon-only button needs an accessible name naming the keyword'
+		);
+	});
+
+	test('a target path containing a quote still renders a working remove button', () => {
+		const LeakLockPanel = require('../leakLockPanel');
+		const panel = new LeakLockPanel({ fsPath: '/tmp/ext' });
+		panel._removalState.targets = [{ path: "/tmp/John's notes.txt", type: 'file' }];
+
+		const html = panel._getRemoveFilesHtml();
+
+		assert.ok(
+			html.includes('data-remove-target="/tmp/John&#039;s notes.txt"'),
+			'the path must travel in a data attribute, escaped'
+		);
+		assert.ok(
+			!/removeTarget\('/.test(html),
+			'no path may be interpolated into an inline handler'
+		);
+	});
+
+	test('escaping lives in one module, not one copy per webview', () => {
+		// The two copies had already drifted - &#39; against &#039;, one coercing
+		// non-strings and one not. Whichever copy receives the next fix, the other
+		// surface silently keeps the bug.
+		for (const file of ['leakLockPanel.js', 'leakLockSidebarProvider.js']) {
+			const src = fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+			assert.ok(
+				!/function escapeHtml\b/.test(src),
+				file + ' must not define its own escapeHtml'
+			);
+			assert.ok(
+				/require\('\.\/html-escape'\)/.test(src),
+				file + ' must use the shared html-escape module'
+			);
+		}
+	});
+
+	test('escapeHtml neutralises both quote characters', () => {
+		// A single quote matters as much as a double quote here: it is what breaks
+		// a handler written with single-quoted arguments.
+		const { escapeHtml } = require('../html-escape');
+		assert.strictEqual(escapeHtml('a"b\'c&d<e>'), 'a&quot;b&#039;c&amp;d&lt;e&gt;');
+	});
+});


### PR DESCRIPTION
Two things, kept together because the dependency work has to land in the same release.

## 1. Git History keyword removal never worked

The ✕ next to a keyword in **Git History Search → Keywords** did nothing.

Each remove button was rendered as `onclick="removeKeyword(${JSON.stringify(k)})"`. `JSON.stringify("aws")` produces `"aws"` — a double-quoted string inside a double-quoted HTML attribute — so the attribute ended at the first inner quote and the parsed handler was the fragment `removeKeyword(`. Every click raised a syntax error in the webview instead of posting a message, so the extension-side `removeGitHistoryKeyword` handler was never reached. `addKeyword()` takes no arguments, which is why adding worked and removing did not.

- Keywords now travel in a `data-keyword` attribute read by a delegated `click` listener — no user input interpolated into JavaScript source.
- Keywords are HTML-escaped in both the label and the attribute. Previously a keyword containing markup such as `<img onerror=…>` executed inside the sidebar webview.
- The list keeps its place across the re-render that follows every edit. Removing holds the scroll position and focuses the keyword that shifted into the freed slot (clamped to the last entry, falling back to the input when the list empties); adding scrolls to the new entry and focuses the input. The flag rides in `vscode.setState()`, which survives the document swap that `_updateView()` performs.

## 2. Dependency upgrades (supersedes #96 and #97)

Dependabot's versions were right; its picture of the platform was not. `vsce` rejects a `@types/vscode` newer than `engines.vscode`, and `vsce` runs only in `publish.yml` — **after** the merge to main. Taking #96 alone would have passed CI and then broken publishing:

```
ERROR  @types/vscode 1.125.0 greater than engines.vscode ^1.96.0.
       Either upgrade engines.vscode or use an older @types/vscode version
```

- **Minimum VS Code raised to 1.125.0** (was 1.96.0). `engines.vscode`, `@types/vscode` and the `.vscode-test.mjs` target move in lockstep; README badge and `docs/TESTING.md` follow. Users below 1.125 stop receiving updates — deliberate.
- **`@types/node` → 26.1.2.** The 1.125 host runs Node 24.15.0 (Electron 42), so the types sit two majors ahead of the runtime — the same gap `^22` had against the old 1.96 host's Node 20.18.1.
- **`globals` → 17.9.0.**
- **brace-expansion advisory GHSA-rgw5-rvv9-x895 cleared.** The advisory bypasses the mitigation the existing `5.0.8` pin relied on, and that pin was scoped to `overrides.mocha`, leaving `@vscode/test-cli`'s own `minimatch` branch uncovered. A top-level override on `5.0.9` takes `npm audit` from four high findings to zero.
- **CI now runs `vsce package` on pull requests**, so this coupling is caught before a merge instead of after one.

#96 and #97 close automatically once this lands, since both target versions are present.

## Verification

| Check | Result |
|---|---|
| `npm run lint` | 0 errors (37 pre-existing warnings) |
| `npm test` | 226 passing against the 1.125 host |
| `npm audit` | 0 vulnerabilities (was 4 high) |
| `vsce package` | succeeds — 43 files, 175 KB |
| Keyword focus/scroll | all four cases checked against a stubbed DOM |

The webview focus behaviour has not been exercised by hand in the extension host.