### PR TITLE
release: 0.7.4 — dependency panel covers every engine, version realigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## 0.7.4
+### Added
+- **The Dependencies panel accounts for every scan engine**: it described Docker, the Nosey Parker image, Java and BFG — none of which a default scan uses — while Gitleaks and TruffleHog, which do the scanning, had no row at all. A missing Gitleaks binary was therefore invisible in the one place a user checks their setup. Expanding the block now lists each engine with its installed version, and an engine that is enabled but not installed is called out with the consequence, because a scan that silently runs one engine short looks exactly like a clean result.
+- **The panel reports which Leak Lock is running**, read from the loaded extension, along with the pinned Nosey Parker image version. Both appear only when the block is expanded.
+
+### Fixed
+- **The repository version matches what is published**: `publish.yml` auto-bumps the patch version on the runner when a tag for the current version already exists, and never commits that bump back. 0.7.3 was published from a repository that still said 0.7.2, and the next merge would have tried to publish and tag 0.7.3 a second time and failed on both. Set to 0.7.4, which is unpublished, so the next release ships exactly what the repository claims to be.
+
+## 0.7.3
+### Security
+- **js-yaml advisory GHSA-5p4m-2wfm-xmqj** (quadratic CPU consumption in `!!omap` resolution): updated to 4.3.1 through `@vscode/test-cli` and mocha. Development dependency only; nothing in the packaged extension was affected.
+
 ## 0.7.2
 ### Changed
 - **The lint run is silent, and stays that way**: 36 unused-symbol warnings were annotating every CI run, which made the real signal easy to miss. Dead code is gone, unused catch bindings use `catch {}`, and parameters kept to document an API signature are named with a leading underscore. `npm run lint` now fails on any new warning, so the count cannot creep back.

--- a/leakLockSidebarProvider.js
+++ b/leakLockSidebarProvider.js
@@ -5,6 +5,9 @@ const fs = require('fs');
 // The pinned Nosey Parker image. Checking or pulling `:latest` here while the scanner
 // runs the pinned tag meant these two disagreed about which image mattered.
 const scanEngineConfig = require('./scan-engine-config');
+// The native engines answer "installed?" and "which version?" themselves, so the
+// panel asks them rather than carrying a second detection path that can disagree.
+const scanEngines = require('./scan-engines');
 // Keywords are user-supplied and land in both element text and attribute values,
 // so they must be escaped before interpolation into the webview HTML. Shared with
 // leakLockPanel.js so both webviews escape identically.
@@ -22,6 +25,10 @@ class LeakLockSidebarProvider {
         this._workspaceGitRepo = null;
         this._showDependencyDetails = false;
         this._showGitHistorySection = false;
+        // Native engine probe results. null until the details are opened, because
+        // probing spawns a subprocess per engine and the compact view never shows it.
+        this._engineStatus = null;
+        this._engineProbeInFlight = false;
     }
 
     resolveWebviewView(webviewView, _context, _token) {
@@ -57,6 +64,9 @@ class LeakLockSidebarProvider {
                     case 'showDependencyDetails':
                         this._showDependencyDetails = true;
                         this._updateView();
+                        // Probing costs a subprocess per engine, so it happens on expand
+                        // rather than on every render. _refreshEngineStatus never rejects.
+                        this._refreshEngineStatus();
                         break;
                     case 'hideDependencyDetails':
                         this._showDependencyDetails = false;
@@ -594,6 +604,81 @@ class LeakLockSidebarProvider {
         </html>`;
     }
 
+    /**
+     * Which Leak Lock is running.
+     *
+     * Read from the loaded extension rather than the checked-out package.json, so a
+     * development host and an installed build cannot report the same number while
+     * running different code. Falls back to the manifest when the extension host is
+     * not available, which is the case in unit tests.
+     *
+     * Only rendered in the expanded block: the compact view is a status line, and a
+     * version number there is noise until someone is actually diagnosing something.
+     */
+    _getInstalledVersionHtml() {
+        let version;
+        try {
+            version = vscode.extensions.getExtension('nikolareljin.leak-lock')?.packageJSON?.version;
+        } catch {
+            version = undefined;
+        }
+        if (!version) {
+            version = require('./package.json').version;
+        }
+        return `
+            <div style="font-size: 11px; color: var(--vscode-descriptionForeground); margin-bottom: 12px;">
+                <strong>Leak Lock</strong> v${escapeHtml(version)}
+            </div>`;
+    }
+
+    /**
+     * The engines that actually scan, with their installed versions.
+     *
+     * Rendered only inside the expanded block: the compact view is a one-line "ready"
+     * summary, and probing three binaries to fill a line nobody opened is work for
+     * nothing.
+     */
+    _getEngineStatusHtml() {
+        const label = (text) =>
+            `<div style="margin: 0 0 6px 0; font-size: 11px; color: var(--vscode-descriptionForeground);"><strong>${text}</strong></div>`;
+        const note = (text, colour = 'var(--vscode-descriptionForeground)') =>
+            `<div style="font-size: 10px; color: ${colour}; margin-left: 20px; margin-bottom: 5px;">${text}</div>`;
+
+        if (this._engineProbeInFlight && !this._engineStatus) {
+            return label('Scan engines:') + note('Checking installed engines…');
+        }
+        if (!this._engineStatus) {
+            return '';
+        }
+
+        const rows = this._engineStatus.map(engine => {
+            // An engine that is enabled but missing is the case worth flagging: the scan
+            // still runs, reports fewer findings, and looks identical to a clean result.
+            const icon = engine.installed ? '✅' : (engine.enabled ? '⚠️' : '➖');
+            const name = escapeHtml(engine.displayName);
+            let detail;
+            if (engine.installed) {
+                detail = note(escapeHtml(engine.version || 'installed, version not reported')
+                    + (engine.enabled ? '' : ' — disabled in leakLock.scan.engines'));
+            } else if (engine.enabled) {
+                detail = note(
+                    `Not installed, but enabled in leakLock.scan.engines — scans run without it. `
+                    + `<a href="${escapeHtml(engine.installHint)}">Install ${name}</a>`,
+                    'var(--vscode-inputValidation-warningForeground)'
+                );
+            } else {
+                detail = note('Not installed, not enabled');
+            }
+            return `
+                <div class="status-item">
+                    <span><span class="status-icon">${icon}</span>${name}</span>
+                </div>
+                ${detail}`;
+        }).join('');
+
+        return label('Scan engines:') + rows;
+    }
+
     _getDependenciesSection() {
         // If all dependencies are met and details not requested, show compact status
         if (this._dependenciesInstalled && !this._isInstalling && !this._showDependencyDetails) {
@@ -625,8 +710,12 @@ class LeakLockSidebarProvider {
         return `
             <div class="section">
                 <h3>🔧 Dependencies Setup</h3>
-                
-                <div style="margin-bottom: 15px; font-size: 11px; color: var(--vscode-descriptionForeground);">
+
+                ${this._getInstalledVersionHtml()}
+
+                ${this._getEngineStatusHtml()}
+
+                <div style="margin: 15px 0 10px 0; font-size: 11px; color: var(--vscode-descriptionForeground);">
                     <!-- Docker is not required to scan any more: Gitleaks and TruffleHog are
                          native binaries. It is needed only by the optional Nosey Parker
                          engine, whose upstream is archived. Labelling it "required" told
@@ -687,6 +776,11 @@ class LeakLockSidebarProvider {
                     <span><span class="status-icon">${noseyparkerStatus}</span>Nosey Parker Image</span>
                     ${showSpinner && this._dependencyStatus?.docker?.installed && !this._dependencyStatus?.noseyparker?.installed ? '<div class="spinner"></div>' : ''}
                 </div>
+                ${this._dependencyStatus?.noseyparker?.installed ? `
+                    <div style="font-size: 10px; color: var(--vscode-descriptionForeground); margin-left: 20px; margin-bottom: 5px;">
+                        ${escapeHtml(scanEngineConfig.NOSEYPARKER_PINNED_VERSION)} (pinned image)
+                    </div>
+                ` : ''}
                 ${this._dependencyStatus?.noseyparker?.error ? `
                     <div style="font-size: 10px; color: var(--vscode-inputValidation-errorForeground); margin-left: 20px; margin-bottom: 5px;">
                         ${this._dependencyStatus.noseyparker.error}
@@ -1021,6 +1115,71 @@ class LeakLockSidebarProvider {
             this._dependencyStatus.noseyparker.installed;
 
         this._updateView();
+
+        // When Docker or the image is missing the detailed view renders anyway, so the
+        // engine rows are on screen and should carry real answers rather than a prompt.
+        if (!this._dependenciesInstalled) {
+            this._refreshEngineStatus();
+        }
+    }
+
+    /**
+     * Probe the native scan engines for presence and version.
+     *
+     * Gitleaks and TruffleHog are the engines that actually run by default; Docker and
+     * the Nosey Parker image are optional and belong to an archived upstream. The panel
+     * described only the optional pair, so a user whose Gitleaks binary was missing had
+     * nowhere to see it — which is the same silence the coverage panel exists to break.
+     *
+     * The engines already know how to answer both questions, so this asks them rather
+     * than reimplementing detection. Deliberately lazy: one subprocess per engine, run
+     * only when the block is expanded.
+     */
+    async _refreshEngineStatus() {
+        if (this._engineProbeInFlight) {
+            return;
+        }
+        this._engineProbeInFlight = true;
+        this._updateView();
+
+        try {
+            const config = vscode.workspace.getConfiguration('leakLock');
+            const configured = config.get('scan.engines');
+            const enabled = new Set(
+                Array.isArray(configured) && configured.length
+                    ? configured
+                    : ['gitleaks', 'trufflehog', 'noseyparker']
+            );
+
+            this._engineStatus = await Promise.all(
+                Object.values(scanEngines.ENGINES).map(async engine => {
+                    // Honours leakLock.<engine>.binaryPath, so a binary outside PATH
+                    // reports as present here exactly as it does during a scan.
+                    const binary = config.get(`${engine.id}.binaryPath`) || undefined;
+                    let installed = false;
+                    let version = null;
+                    try {
+                        installed = await engine.isAvailable({ binary });
+                        if (installed) {
+                            version = await engine.version({ binary });
+                        }
+                    } catch {
+                        installed = false;
+                    }
+                    return {
+                        id: engine.id,
+                        displayName: engine.displayName,
+                        installHint: engine.installHint,
+                        enabled: enabled.has(engine.id),
+                        installed,
+                        version
+                    };
+                })
+            );
+        } finally {
+            this._engineProbeInFlight = false;
+            this._updateView();
+        }
     }
 
     async _detectGitRepository() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "leak-lock",
-  "version": "0.7.2",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "leak-lock",
-      "version": "0.7.2",
+      "version": "0.7.4",
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "^26.1.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "leak-lock",
   "description": "Developer tools to help engineers stay cybersecure without interrupting their workflows",
   "icon": "media/icon.png",
-  "version": "0.7.2",
+  "version": "0.7.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/nikolareljin/leak-lock.git"

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -3486,3 +3486,117 @@ suite('User text never reaches a webview event handler', () => {
 		assert.strictEqual(escapeHtml('a"b\'c&d<e>'), 'a&quot;b&#039;c&amp;d&lt;e&gt;');
 	});
 });
+
+suite('The dependency panel accounts for every scan engine', () => {
+	const { LeakLockSidebarProvider } = require('../leakLockSidebarProvider');
+	const scanEngines = require('../scan-engines');
+
+	// The panel described Docker, the Nosey Parker image, Java and BFG — none of
+	// which the default scan uses. Gitleaks and TruffleHog do the scanning and had
+	// no row at all, so a missing Gitleaks binary was invisible in the one place a
+	// user goes to check their setup.
+
+	function provider() {
+		return new LeakLockSidebarProvider(vscode.Uri.file(__dirname));
+	}
+
+	test('nothing is rendered until the block is expanded', () => {
+		// Probing spawns a subprocess per engine. The compact "Dependencies ready"
+		// line does not show the result, so it must not pay for one.
+		const p = provider();
+		assert.strictEqual(p._engineStatus, null, 'engines must not be probed on construction');
+		assert.strictEqual(p._getEngineStatusHtml(), '', 'unprobed engines render nothing');
+	});
+
+	test('an expanded block lists every engine with its installed version', () => {
+		const p = provider();
+		p._engineStatus = [
+			{ id: 'gitleaks', displayName: 'Gitleaks', installHint: 'https://example.invalid/gl', enabled: true, installed: true, version: 'v8.28.0' },
+			{ id: 'trufflehog', displayName: 'TruffleHog', installHint: 'https://example.invalid/th', enabled: true, installed: true, version: 'v3.90.10' }
+		];
+		const html = p._getEngineStatusHtml();
+
+		assert.ok(html.includes('Gitleaks') && html.includes('v8.28.0'), 'Gitleaks and its version must appear');
+		assert.ok(html.includes('TruffleHog') && html.includes('v3.90.10'), 'TruffleHog and its version must appear');
+	});
+
+	test('an engine that is enabled but missing is flagged, not quietly omitted', () => {
+		// This is the case that matters: the scan still runs, finds less, and looks
+		// exactly like a clean result.
+		const p = provider();
+		p._engineStatus = [
+			{ id: 'gitleaks', displayName: 'Gitleaks', installHint: 'https://example.invalid/gl', enabled: true, installed: false, version: null }
+		];
+		const html = p._getEngineStatusHtml();
+
+		assert.ok(html.includes('Gitleaks'), 'a missing engine still gets a row');
+		assert.ok(/scans run without it/.test(html), 'the consequence must be stated');
+		assert.ok(html.includes('https://example.invalid/gl'), 'the install hint must be offered');
+	});
+
+	test('an installed engine that is switched off says so rather than looking broken', () => {
+		const p = provider();
+		p._engineStatus = [
+			{ id: 'trufflehog', displayName: 'TruffleHog', installHint: 'https://example.invalid/th', enabled: false, installed: true, version: 'v3.90.10' }
+		];
+		const html = p._getEngineStatusHtml();
+
+		assert.ok(html.includes('v3.90.10'), 'the version is still reported');
+		assert.ok(/disabled in leakLock\.scan\.engines/.test(html), 'and the reason it will not run');
+	});
+
+	test('the expanded block reports which Leak Lock is running', () => {
+		// The version a user reports in a bug is the one the panel showed them, so it
+		// has to come from the loaded extension rather than a hardcoded string.
+		const p = provider();
+		const html = p._getInstalledVersionHtml();
+		const manifest = require('../package.json').version;
+		const loaded = vscode.extensions.getExtension('nikolareljin.leak-lock')?.packageJSON?.version;
+
+		assert.ok(html.includes('Leak Lock'), 'the product is named');
+		assert.ok(
+			html.includes('v' + (loaded || manifest)),
+			'the running version must be shown, not omitted'
+		);
+	});
+
+	test('probing asks the engines themselves, honouring a configured binary path', async () => {
+		// A second detection path would be free to disagree with the one the scan
+		// uses. This asserts the panel calls the engine, with the same binaryPath
+		// override a scan would apply.
+		const p = provider();
+		const gitleaks = scanEngines.ENGINES.gitleaks;
+		const truffle = scanEngines.ENGINES.trufflehog;
+		const originals = [gitleaks.isAvailable, gitleaks.version, truffle.isAvailable, truffle.version];
+		const originalGet = vscode.workspace.getConfiguration;
+		const seen = {};
+
+		vscode.workspace.getConfiguration = () => ({
+			get: (key) => {
+				if (key === 'scan.engines') { return ['gitleaks']; }
+				if (key === 'gitleaks.binaryPath') { return '/opt/custom/gitleaks'; }
+				return undefined;
+			}
+		});
+		gitleaks.isAvailable = async (opts) => { seen.gitleaksBinary = opts?.binary; return true; };
+		gitleaks.version = async () => 'v8.28.0';
+		truffle.isAvailable = async () => false;
+		truffle.version = async () => null;
+
+		try {
+			await p._refreshEngineStatus();
+		} finally {
+			[gitleaks.isAvailable, gitleaks.version, truffle.isAvailable, truffle.version] = originals;
+			vscode.workspace.getConfiguration = originalGet;
+		}
+
+		assert.strictEqual(seen.gitleaksBinary, '/opt/custom/gitleaks', 'binaryPath must reach the engine');
+		const byId = Object.fromEntries(p._engineStatus.map(e => [e.id, e]));
+		assert.deepStrictEqual(
+			{ installed: byId.gitleaks.installed, version: byId.gitleaks.version, enabled: byId.gitleaks.enabled },
+			{ installed: true, version: 'v8.28.0', enabled: true }
+		);
+		assert.strictEqual(byId.trufflehog.installed, false);
+		assert.strictEqual(byId.trufflehog.enabled, false, 'not listed in scan.engines');
+	});
+});


### PR DESCRIPTION
## 1. The Dependencies panel described the wrong things

It listed Docker, the Nosey Parker image, Java and BFG. **None of those are used by a default scan** — Docker is optional and only for Nosey Parker, whose upstream is archived. Gitleaks and TruffleHog do the actual scanning and had **no row at all**, so a missing Gitleaks binary was invisible in the one place a user goes to check their setup.

Expanding the block now shows:

| Row | Shows |
|---|---|
| **Leak Lock** | the running version, read from the loaded extension |
| **Gitleaks** | installed + version, or a warning if enabled and missing |
| **TruffleHog** | installed + version, or a warning if enabled and missing |
| **Nosey Parker Image** | the pinned image version |
| Docker / Java / BFG | unchanged |

An engine that is **enabled in `leakLock.scan.engines` but not installed** is flagged with the consequence spelled out — *"scans run without it"* — plus its install link. That is the case worth shouting about: the scan still completes, reports fewer findings, and is indistinguishable from a clean repository. It is the same silence the 0.7.0 coverage panel exists to break, one layer earlier.

**Detection asks the engines themselves** (`isAvailable()` / `version()` from `scan-engines.js`, honouring `leakLock.<engine>.binaryPath`) rather than adding a second detection path free to disagree with the one a scan uses. It runs **only on expand** — each probe costs a subprocess and the compact "Dependencies ready" line never shows the result.

## 2. The repository version did not match what is published

`publish.yml` bumps the patch version on the runner when a tag for the current version already exists, and **never commits that bump back**. So:

```
main package.json : 0.7.2
tags              : v0.7.1  v0.7.2  v0.7.3
Marketplace       : 0.7.3
```

The next merge would have read 0.7.2, seen `v0.7.2`, bumped to 0.7.3 — already published, already tagged — and failed both `vsce publish` and `git tag`.

Set to **0.7.4** rather than 0.7.3 deliberately: 0.7.3 would re-arm the same trap, because the workflow would find `v0.7.3` and bump past it again, leaving the repo permanently one version behind. `v0.7.4` does not exist, so the next publish ships exactly what the repo says it is. CHANGELOG records 0.7.3 as it actually shipped.

The underlying auto-bump behaviour is untouched here — it belongs in the shared publisher tracked as nikolareljin/ci-helpers#128.

## Verification

| Check | Result |
|---|---|
| `npm run lint` | clean under `--max-warnings 0` |
| `npm test` | 236 passing (6 new) |
| `vsce package` | succeeds — 42 files, 182 KB |

New tests cover: nothing probed before expansion, every engine listed with its version, an enabled-but-missing engine flagged rather than omitted, an installed-but-disabled engine explained rather than looking broken, the running version reported, and probing delegating to the engines with `binaryPath` honoured.

Not verified by hand in the extension host — worth an F5 and expanding **Details** to confirm the rows read well.