### PR TITLE
fix: Windows git-filter-repo path, scan timeout, and commit permalink…

### DIFF
--- a/docs/SCANNING_ENGINES.md
+++ b/docs/SCANNING_ENGINES.md
@@ -456,6 +456,6 @@ caveat.
 |---|---|---|
 | `leakLock.scan.engines` | `["gitleaks","trufflehog"]` | Which engines run, in order. Add `"noseyparker"` to include the archived container-image engine |
 | `leakLock.scan.executionMode` | `auto` | `auto`, `parallel`, `sequential` or `single` — see [How many engines run at once](#how-many-engines-run-at-once) |
-| `leakLock.scan.timeoutSeconds` | `300` | Per-engine timeout. On expiry, partial findings are reported and marked incomplete |
+| `leakLock.scan.timeoutSeconds` | `600` | Per-engine timeout. On expiry, partial findings are reported and marked incomplete |
 | `leakLock.scan.refreshRefsBeforeScan` | `true` | `git fetch --tags` first, so remote-only branches are not invisible. Read-only: the scan never prunes — only the refresh immediately before a rewrite does, where the plan must match the server exactly |
 | `leakLock.dependencyHandling` | `warning` | `exclude` skips only unambiguously third-party directories — `lib/`, `bin/`, `dist/` and `build/` are still scanned, because skipping them would hide real secrets |

--- a/git-permalink.js
+++ b/git-permalink.js
@@ -4,26 +4,59 @@
 // provider names out of git *error text* so a remediation message can name the
 // right UI; it never sees a URL and cannot produce an owner or repo.
 //
-// Unknown hosts — self-hosted GitLab, GitHub Enterprise, internal Gitea —
-// return null on purpose. A guessed URL shape produces a 404 that looks like
-// leak-lock pointing at the wrong commit, which is worse than plain text.
+// Well-known SaaS hosts are matched exactly. Every other valid git remote is
+// supported too: the platform is inferred from the hostname (a host containing
+// "gitlab" uses GitLab's /-/blob/ path shape; one containing "gitea", "forgejo"
+// or "gogs" uses Gitea's /src/commit/ shape; everything else — GitHub Enterprise,
+// Azure DevOps-style, generic self-hosted — gets GitHub's /blob/ shape, which is
+// the most widely adopted layout).
 
-const HOSTS = Object.freeze({
-    'github.com': {
-        build: (owner, repo, sha, encodedPath, line) =>
-            `https://github.com/${owner}/${repo}/blob/${sha}/${encodedPath}` + (line ? `#L${line}` : '')
+// URL builders per platform. The host is the first argument so the same
+// function serves both well-known SaaS hosts and any self-hosted instance at an
+// arbitrary hostname.
+const PLATFORMS = Object.freeze({
+    github: {
+        build: (host, owner, repo, sha, encodedPath, line) =>
+            `https://${host}/${owner}/${repo}/blob/${sha}/${encodedPath}` + (line ? `#L${line}` : '')
     },
-    'gitlab.com': {
-        build: (owner, repo, sha, encodedPath, line) =>
-            `https://gitlab.com/${owner}/${repo}/-/blob/${sha}/${encodedPath}` + (line ? `#L${line}` : '')
+    gitlab: {
+        build: (host, owner, repo, sha, encodedPath, line) =>
+            `https://${host}/${owner}/${repo}/-/blob/${sha}/${encodedPath}` + (line ? `#L${line}` : '')
     },
-    'bitbucket.org': {
-        build: (owner, repo, sha, encodedPath, line) =>
-            `https://bitbucket.org/${owner}/${repo}/src/${sha}/${encodedPath}` + (line ? `#lines-${line}` : '')
+    bitbucket: {
+        build: (host, owner, repo, sha, encodedPath, line) =>
+            `https://${host}/${owner}/${repo}/src/${sha}/${encodedPath}` + (line ? `#lines-${line}` : '')
+    },
+    gitea: {
+        build: (host, owner, repo, sha, encodedPath, line) =>
+            `https://${host}/${owner}/${repo}/src/commit/${sha}/${encodedPath}` + (line ? `#L${line}` : '')
     }
 });
 
-const SUPPORTED_HOSTS = Object.freeze(Object.keys(HOSTS));
+// Canonical SaaS hostnames → platform key.
+const BUILT_IN_HOSTS = Object.freeze({
+    'github.com': 'github',
+    'gitlab.com': 'gitlab',
+    'bitbucket.org': 'bitbucket'
+});
+
+const SUPPORTED_PLATFORMS = Object.freeze(Object.keys(PLATFORMS));
+
+/**
+ * Infer which URL layout a self-hosted Git instance most likely uses.
+ *
+ * The hostname is the only signal available without making a network request.
+ * Operators commonly include the product name in their hostname
+ * (gitlab.acme.com, gitea.internal, forgejo.dev, …), so keyword matching covers
+ * the most common cases. Everything else defaults to GitHub's /blob/ layout,
+ * which GitHub Enterprise and most generic hosts share.
+ */
+function inferPlatform(host) {
+    if (/gitlab/i.test(host)) { return 'gitlab'; }
+    if (/bitbucket/i.test(host)) { return 'bitbucket'; }
+    if (/gitea|forgejo|gogs/i.test(host)) { return 'gitea'; }
+    return 'github';
+}
 
 // Only the forms git itself writes into `remote.get-url`. `file://` and
 // anything exotic is refused rather than parsed.
@@ -49,7 +82,21 @@ function splitOwnerRepo(pathPart) {
     };
 }
 
-function parseRemote(url) {
+/**
+ * Parse a git remote URL into the fields needed to build a commit permalink.
+ *
+ * Accepts any remote that git itself accepts (https://, http://, ssh://, git://,
+ * and SCP-like git@host:owner/repo). Returns { host, owner, repo, platform }
+ * where platform selects the URL layout; returns null only when the URL cannot
+ * be parsed into an owner and repo (missing path segments, bad scheme, etc.).
+ *
+ * @param {string} url  The remote URL (e.g. from `git remote get-url origin`).
+ * @param {Record<string,string>} [customHostTypes]  Optional map of hostname →
+ *   platform name supplied from user configuration. Checked before heuristics,
+ *   so `{ "git.acme.com": "gitlab" }` forces GitLab's URL format for that host
+ *   even though its name contains no platform keyword.
+ */
+function parseRemote(url, customHostTypes = {}) {
     if (typeof url !== 'string') {
         return null;
     }
@@ -82,16 +129,18 @@ function parseRemote(url) {
         pathPart = match[2];
     }
 
-    if (!Object.hasOwn(HOSTS, host)) {
-        return null;
-    }
-
     const ownerRepo = splitOwnerRepo(pathPart);
     if (!ownerRepo) {
         return null;
     }
 
-    return { host, owner: ownerRepo.owner, repo: ownerRepo.repo };
+    const platform =
+        BUILT_IN_HOSTS[host] ||
+        (customHostTypes && Object.hasOwn(customHostTypes, host) && Object.hasOwn(PLATFORMS, customHostTypes[host])
+            ? customHostTypes[host]
+            : null) ||
+        inferPlatform(host);
+    return { host, owner: ownerRepo.owner, repo: ownerRepo.repo, platform };
 }
 
 function encodePath(file) {
@@ -101,7 +150,7 @@ function encodePath(file) {
 }
 
 function buildCommitUrl(remote, { commitHash, file, line } = {}) {
-    if (!remote || !Object.hasOwn(HOSTS, remote.host)) {
+    if (!remote || !remote.platform || !Object.hasOwn(PLATFORMS, remote.platform)) {
         return null;
     }
     if (typeof commitHash !== 'string' || !HEX_SHA.test(commitHash)) {
@@ -111,7 +160,8 @@ function buildCommitUrl(remote, { commitHash, file, line } = {}) {
         return null;
     }
     const anchorLine = Number.isFinite(line) && line > 0 ? line : null;
-    return HOSTS[remote.host].build(
+    return PLATFORMS[remote.platform].build(
+        remote.host,
         encodePath(remote.owner),
         encodeURIComponent(remote.repo),
         commitHash,
@@ -124,8 +174,13 @@ function buildCommitUrl(remote, { commitHash, file, line } = {}) {
  * Would this URL have been produced by `buildCommitUrl`? The host re-checks
  * before opening a browser, so that a message from the webview can never turn
  * `openExternal` into a launcher for an arbitrary address.
+ *
+ * For well-known SaaS hosts the hostname alone is the guard. For self-hosted
+ * instances, remoteInfo (the parsed origin remote of the scanned repository)
+ * is required so the check remains specific: only the host the repository
+ * actually lives on is accepted, not any arbitrary https address.
  */
-function isPermalinkUrl(url) {
+function isPermalinkUrl(url, remoteInfo = null) {
     if (typeof url !== 'string' || !url) {
         return false;
     }
@@ -135,7 +190,16 @@ function isPermalinkUrl(url) {
     } catch {
         return false;
     }
-    return parsed.protocol === 'https:' && Object.hasOwn(HOSTS, parsed.hostname.toLowerCase());
+    if (parsed.protocol !== 'https:') {
+        return false;
+    }
+    const host = parsed.hostname.toLowerCase();
+    if (Object.hasOwn(BUILT_IN_HOSTS, host)) {
+        return true;
+    }
+    // Custom host: accept only if it matches the repository's own remote,
+    // so a crafted webview message cannot redirect the browser elsewhere.
+    return remoteInfo != null && host === remoteInfo.host.toLowerCase();
 }
 
-module.exports = { parseRemote, buildCommitUrl, isPermalinkUrl, SUPPORTED_HOSTS };
+module.exports = { parseRemote, buildCommitUrl, isPermalinkUrl, SUPPORTED_PLATFORMS };

--- a/git-permalink.js
+++ b/git-permalink.js
@@ -42,6 +42,19 @@ const BUILT_IN_HOSTS = Object.freeze({
 
 const SUPPORTED_PLATFORMS = Object.freeze(Object.keys(PLATFORMS));
 
+function normalizeCustomHostTypes(customHostTypes) {
+    if (!customHostTypes || typeof customHostTypes !== 'object') {
+        return {};
+    }
+    const normalized = {};
+    for (const [hostname, platform] of Object.entries(customHostTypes)) {
+        if (typeof hostname === 'string' && typeof platform === 'string') {
+            normalized[hostname.toLowerCase()] = platform;
+        }
+    }
+    return normalized;
+}
+
 /**
  * Infer which URL layout a self-hosted Git instance most likely uses.
  *
@@ -134,10 +147,11 @@ function parseRemote(url, customHostTypes = {}) {
         return null;
     }
 
+    const normalizedHostTypes = normalizeCustomHostTypes(customHostTypes);
     const platform =
         BUILT_IN_HOSTS[host] ||
-        (customHostTypes && Object.hasOwn(customHostTypes, host) && Object.hasOwn(PLATFORMS, customHostTypes[host])
-            ? customHostTypes[host]
+        (Object.hasOwn(normalizedHostTypes, host) && Object.hasOwn(PLATFORMS, normalizedHostTypes[host])
+            ? normalizedHostTypes[host]
             : null) ||
         inferPlatform(host);
     return { host, owner: ownerRepo.owner, repo: ownerRepo.repo, platform };

--- a/git-rewrite.js
+++ b/git-rewrite.js
@@ -199,6 +199,34 @@ function describeSandboxedFilterRepo(output, rulesPath) {
 }
 
 /**
+ * Resolve the Python user scripts directory on Windows.
+ *
+ * `pip install --user` places executables in the per-user Scripts directory
+ * (e.g. %APPDATA%\Python\Python312\Scripts), which is NOT added to PATH by the
+ * Python installer by default.  Asking sysconfig for the path is the only
+ * reliable way to find it without guessing a version number.
+ *
+ * Tries the same Python interpreters that the install command may have used, in
+ * the same priority order, so what we find matches what pip wrote.
+ *
+ * @returns {Promise<string|null>} Absolute path to the Scripts directory, or null.
+ */
+async function findWindowsUserScriptsDir() {
+    const script = "import sysconfig; print(sysconfig.get_path('scripts', 'nt_user'))";
+    for (const cmd of ['python', 'py', 'python3']) {
+        try {
+            const { stdout } = await execFileAsync(cmd, ['-c', script],
+                { maxBuffer: MAX_BUFFER, timeout: 10000 });
+            const dir = String(stdout).trim();
+            if (dir) {
+                return dir;
+            }
+        } catch { /* try next interpreter */ }
+    }
+    return null;
+}
+
+/**
  * Which form of git-filter-repo this machine has, if any.
  *
  * Two installations are both valid and neither implies the other: pip drops a
@@ -206,6 +234,11 @@ function describeSandboxedFilterRepo(output, rulesPath) {
  * it in git's exec-path so `git filter-repo` resolves. Probing both is the only
  * way to answer "can a Git-only cleanup run here", which is what the setup panel
  * needs to state before the user selects anything.
+ *
+ * On Windows, pip's `--user` install lands in a per-version Scripts directory
+ * (%APPDATA%\Python\PythonXY\Scripts) that is not on PATH by default. When
+ * neither standard probe succeeds, the user Scripts directory is searched as a
+ * last resort so the tool is reported as available rather than missing.
  *
  * @returns {Promise<{installed: boolean, form: string|null, version: string|null,
  *                    path: string|null, confined: boolean, error: string|null}>}
@@ -244,6 +277,29 @@ async function detectFilterRepo() {
         };
     } catch (launcherError) {
         const output = failureText(launcherError);
+
+        // On Windows, pip --user installs to a Scripts directory that is often not
+        // on PATH. Try to find the launcher there before reporting it as missing.
+        if (process.platform === 'win32' && /ENOENT|not found/i.test(output)) {
+            try {
+                const scriptsDir = await findWindowsUserScriptsDir();
+                if (scriptsDir) {
+                    const launcherPath = path.join(scriptsDir, 'git-filter-repo.exe');
+                    if (fs.existsSync(launcherPath)) {
+                        const version = await readVersion(launcherPath, ['--version']);
+                        return {
+                            installed: true,
+                            form: 'PATH launcher',
+                            version,
+                            path: launcherPath,
+                            confined: false,
+                            error: null
+                        };
+                    }
+                }
+            } catch { /* probe failed, fall through to the not-installed report */ }
+        }
+
         return {
             installed: false,
             form: null,
@@ -325,6 +381,31 @@ async function runGitFilterRepo(repoDir, args, options = {}) {
             if (launcherError.code !== 'ENOENT') {
                 throw withSandboxHint(launcherError);
             }
+
+            // On Windows, pip --user installs git-filter-repo.exe into a Scripts
+            // directory that is typically not on PATH. Try to find and invoke it
+            // directly before giving up, so the rewrite works without the user
+            // having to modify their environment.
+            if (process.platform === 'win32') {
+                try {
+                    const scriptsDir = await findWindowsUserScriptsDir();
+                    if (scriptsDir) {
+                        const launcherPath = path.join(scriptsDir, 'git-filter-repo.exe');
+                        if (fs.existsSync(launcherPath)) {
+                            return await execFileAsync(launcherPath, args, {
+                                cwd: repoDir,
+                                maxBuffer: MAX_BUFFER,
+                                ...options
+                            });
+                        }
+                    }
+                } catch (userPathError) {
+                    if (userPathError.code !== 'ENOENT') {
+                        throw withSandboxHint(userPathError);
+                    }
+                }
+            }
+
             // Named for the platform this is actually running on: Windows has no
             // python3 shim by default, so quoting one turns a missing dependency
             // into a second dead end.

--- a/git-rewrite.js
+++ b/git-rewrite.js
@@ -289,7 +289,7 @@ async function detectFilterRepo() {
                         const version = await readVersion(launcherPath, ['--version']);
                         return {
                             installed: true,
-                            form: 'PATH launcher',
+                            form: 'pip --user launcher',
                             version,
                             path: launcherPath,
                             confined: false,

--- a/leakLockPanel.js
+++ b/leakLockPanel.js
@@ -16,7 +16,7 @@ const hostCapacity = require('./host-capacity');
 // Shared with leakLockSidebarProvider.js so the two webviews escape identically.
 const { escapeHtml } = require('./html-escape');
 const { findGitRoot, describeFindingPath, repoRelativeCandidates } = require('./finding-paths');
-const { parseRemote, buildCommitUrl, isPermalinkUrl } = require('./git-permalink');
+const { parseRemote, buildCommitUrl, isPermalinkUrl, SUPPORTED_PLATFORMS } = require('./git-permalink');
 const credentialInspect = require('./credential-inspect');
 const { classifyFindings } = require('./credential-prepass');
 const { renderCredentialReportHtml } = require('./credential-report-html');
@@ -3731,6 +3731,22 @@ class LeakLockPanel {
     }
 
     /**
+     * Custom hostname → platform mappings from user configuration.
+     * Keys are lowercased hostnames; values are validated platform names.
+     * Computed on every call (config can change); cheap enough for the call rate.
+     */
+    _customHostTypes() {
+        const raw = vscode.workspace.getConfiguration('leakLock').get('git.customHostTypes') || {};
+        const result = {};
+        for (const [hostname, platform] of Object.entries(raw)) {
+            if (typeof hostname === 'string' && hostname && SUPPORTED_PLATFORMS.includes(platform)) {
+                result[hostname.toLowerCase()] = platform;
+            }
+        }
+        return result;
+    }
+
+    /**
      * Resolved once per scan: the remote does not change mid-run, and every row
      * in the table would otherwise shell out to git for the same answer.
      */
@@ -3741,10 +3757,10 @@ class LeakLockPanel {
         }
         try {
             const remoteUrl = await gitRewrite.getRemoteUrl(scanPath);
-            this._remoteInfo = parseRemote(remoteUrl);
+            this._remoteInfo = parseRemote(remoteUrl, this._customHostTypes());
         } catch {
-            // No remote, not a repository, or a host we do not build URLs for.
-            // The SHA simply stays plain text; this must never fail a scan.
+            // No remote or not a repository. The SHA stays as plain text;
+            // this must never fail a scan.
             this._remoteInfo = null;
         }
     }
@@ -3890,7 +3906,7 @@ class LeakLockPanel {
         }
         await Promise.all([...roots.keys()].map(async (repoRoot) => {
             try {
-                roots.set(repoRoot, parseRemote(await gitRewrite.getRemoteUrl(repoRoot)));
+                roots.set(repoRoot, parseRemote(await gitRewrite.getRemoteUrl(repoRoot), this._customHostTypes()));
             } catch {
                 roots.set(repoRoot, null);
             }
@@ -3934,7 +3950,7 @@ class LeakLockPanel {
             file,
             line: finding.line
         });
-        return url && isPermalinkUrl(url) ? url : null;
+        return url && isPermalinkUrl(url, remoteInfo) ? url : null;
     }
 
     /**
@@ -3972,7 +3988,7 @@ class LeakLockPanel {
             || (repoDir === this._scanRepoRoot ? this._remoteInfo : null);
         if (!remoteInfo) {
             try {
-                remoteInfo = parseRemote(await gitRewrite.getRemoteUrl(repoDir));
+                remoteInfo = parseRemote(await gitRewrite.getRemoteUrl(repoDir), this._customHostTypes());
             } catch {
                 remoteInfo = null;
             }
@@ -3996,7 +4012,7 @@ class LeakLockPanel {
             file,
             line: finding.line
         });
-        return url && isPermalinkUrl(url) ? url : null;
+        return url && isPermalinkUrl(url, remoteInfo) ? url : null;
     }
 
     async _openCommitUrl(findingIndex) {

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
             "type": "string",
             "enum": ["github", "gitlab", "bitbucket", "gitea"]
           },
-          "markdownDescription": "Map self-hosted Git hostnames to their platform type so commit links are built with the right URL format. Keys are hostnames (e.g. `\"git.acme.com\"`), values are one of `\"github\"` (GitHub Enterprise), `\"gitlab\"` (self-hosted GitLab), `\"bitbucket\"` (Bitbucket Server/DC), or `\"gitea\"` (Gitea / Forgejo / Gogs). Well-known SaaS hosts (`github.com`, `gitlab.com`, `bitbucket.org`) are detected automatically and do not need an entry here. For any host that has no entry and no recognisable platform keyword in its hostname, `\"github\"` URL format is assumed as the most common self-hosted layout."
+          "markdownDescription": "Map self-hosted Git hostnames to their platform type so commit links are built with the right URL format. Keys are hostnames (e.g. `\"git.acme.com\"`), values are one of `\"github\"` (GitHub Enterprise), `\"gitlab\"` (self-hosted GitLab), `\"bitbucket\"` (hosts using Bitbucket Cloud URL layout), or `\"gitea\"` (Gitea / Forgejo / Gogs). Well-known SaaS hosts (`github.com`, `gitlab.com`, `bitbucket.org`) are detected automatically and do not need an entry here. For any host that has no entry and no recognisable platform keyword in its hostname, `\"github\"` URL format is assumed as the most common self-hosted layout."
         },
         "leakLock.noseyParker.image": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
         },
         "leakLock.scan.timeoutSeconds": {
           "type": "number",
-          "default": 300,
+          "default": 600,
           "minimum": 30,
           "maximum": 7200,
           "description": "Maximum time for a single engine's scan. On expiry, findings gathered so far are reported and the results are marked incomplete rather than discarded."
@@ -117,6 +117,15 @@
           "type": "boolean",
           "default": true,
           "description": "Run 'git fetch --tags' before scanning, so a branch that exists only as an unfetched remote ref is not missed and the repository cannot be reported clean while the secret is still on the server. The scan's fetch is read-only: it does not pass --prune, so scanning never deletes remote-tracking refs. (The refresh immediately before a history rewrite does prune, because there the plan must match the server exactly.)"
+        },
+        "leakLock.git.customHostTypes": {
+          "type": "object",
+          "default": {},
+          "additionalProperties": {
+            "type": "string",
+            "enum": ["github", "gitlab", "bitbucket", "gitea"]
+          },
+          "markdownDescription": "Map self-hosted Git hostnames to their platform type so commit links are built with the right URL format. Keys are hostnames (e.g. `\"git.acme.com\"`), values are one of `\"github\"` (GitHub Enterprise), `\"gitlab\"` (self-hosted GitLab), `\"bitbucket\"` (Bitbucket Server/DC), or `\"gitea\"` (Gitea / Forgejo / Gogs). Well-known SaaS hosts (`github.com`, `gitlab.com`, `bitbucket.org`) are detected automatically and do not need an entry here. For any host that has no entry and no recognisable platform keyword in its hostname, `\"github\"` URL format is assumed as the most common self-hosted layout."
         },
         "leakLock.noseyParker.image": {
           "type": "string",

--- a/scan-engine-config.js
+++ b/scan-engine-config.js
@@ -27,7 +27,7 @@ const NOSEYPARKER_ARCHIVED_NOTICE =
 const REPORT_NO_LIMIT = '-1';
 const REPORT_NO_MIN_SCORE = '0';
 
-const DEFAULT_SCAN_TIMEOUT_MS = 300000; // 5 minutes
+const DEFAULT_SCAN_TIMEOUT_MS = 600000; // 10 minutes
 const DEFAULT_MAX_FILE_SIZE_MB = 100; // matches Nosey Parker's own default
 
 /**

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -1113,7 +1113,7 @@ suite('Scan engine configuration', () => {
 	test('settings are clamped so an out-of-range value cannot reach the engine', () => {
 		assert.strictEqual(engineConfig.normalizeScanSettings({ timeoutSeconds: 5 }).timeoutMs, 30000);
 		assert.strictEqual(engineConfig.normalizeScanSettings({ timeoutSeconds: 99999 }).timeoutMs, 7200000);
-		assert.strictEqual(engineConfig.normalizeScanSettings({ timeoutSeconds: 'abc' }).timeoutMs, 300000);
+		assert.strictEqual(engineConfig.normalizeScanSettings({ timeoutSeconds: 'abc' }).timeoutMs, 600000);
 		assert.strictEqual(engineConfig.normalizeScanSettings({ maxFileSizeMb: -4 }).maxFileSizeMb, 0);
 	});
 

--- a/test/git-permalink.test.js
+++ b/test/git-permalink.test.js
@@ -8,35 +8,35 @@ suite('parseRemote', () => {
     test('parses the SCP-like SSH form', () => {
         assert.deepStrictEqual(
             parseRemote('git@github.com:nikolareljin/leak-lock.git'),
-            { host: 'github.com', owner: 'nikolareljin', repo: 'leak-lock' }
+            { host: 'github.com', owner: 'nikolareljin', repo: 'leak-lock', platform: 'github' }
         );
     });
 
     test('parses the HTTPS form', () => {
         assert.deepStrictEqual(
             parseRemote('https://github.com/nikolareljin/leak-lock.git'),
-            { host: 'github.com', owner: 'nikolareljin', repo: 'leak-lock' }
+            { host: 'github.com', owner: 'nikolareljin', repo: 'leak-lock', platform: 'github' }
         );
     });
 
     test('parses the ssh:// form', () => {
         assert.deepStrictEqual(
             parseRemote('ssh://git@github.com/nikolareljin/leak-lock.git'),
-            { host: 'github.com', owner: 'nikolareljin', repo: 'leak-lock' }
+            { host: 'github.com', owner: 'nikolareljin', repo: 'leak-lock', platform: 'github' }
         );
     });
 
     test('the .git suffix is optional', () => {
         assert.deepStrictEqual(
             parseRemote('https://github.com/nikolareljin/leak-lock'),
-            { host: 'github.com', owner: 'nikolareljin', repo: 'leak-lock' }
+            { host: 'github.com', owner: 'nikolareljin', repo: 'leak-lock', platform: 'github' }
         );
     });
 
     test('keeps GitLab subgroups in the owner', () => {
         assert.deepStrictEqual(
             parseRemote('git@gitlab.com:group/subgroup/thing.git'),
-            { host: 'gitlab.com', owner: 'group/subgroup', repo: 'thing' }
+            { host: 'gitlab.com', owner: 'group/subgroup', repo: 'thing', platform: 'gitlab' }
         );
     });
 
@@ -44,12 +44,44 @@ suite('parseRemote', () => {
         assert.strictEqual(parseRemote('git@GitHub.COM:o/r.git').host, 'github.com');
     });
 
-    test('an unknown host is null, so no link is offered', () => {
-        assert.strictEqual(parseRemote('git@git.internal.example:o/r.git'), null);
+    test('a self-hosted GitLab is detected by platform keyword in the hostname', () => {
+        assert.deepStrictEqual(
+            parseRemote('https://gitlab.example.com/o/r.git'),
+            { host: 'gitlab.example.com', owner: 'o', repo: 'r', platform: 'gitlab' }
+        );
     });
 
-    test('a self-hosted GitLab is null rather than guessed', () => {
-        assert.strictEqual(parseRemote('https://gitlab.example.com/o/r.git'), null);
+    test('an unrecognised hostname defaults to the github URL layout', () => {
+        assert.deepStrictEqual(
+            parseRemote('git@git.internal.example:o/r.git'),
+            { host: 'git.internal.example', owner: 'o', repo: 'r', platform: 'github' }
+        );
+    });
+
+    test('customHostTypes overrides heuristic detection', () => {
+        assert.deepStrictEqual(
+            parseRemote('https://git.acme.com/o/r.git', { 'git.acme.com': 'gitlab' }),
+            { host: 'git.acme.com', owner: 'o', repo: 'r', platform: 'gitlab' }
+        );
+    });
+
+    test('customHostTypes is case-insensitive on the hostname key', () => {
+        assert.strictEqual(
+            parseRemote('https://git.acme.com/o/r.git', { 'GIT.ACME.COM': 'gitea' }),
+            null // key not matched because we lowercase the parsed host; user must provide lowercase key
+        );
+        // But a lowercase key works:
+        assert.strictEqual(
+            parseRemote('https://git.acme.com/o/r.git', { 'git.acme.com': 'gitea' }).platform,
+            'gitea'
+        );
+    });
+
+    test('an unknown customHostTypes platform value is ignored, heuristic is used instead', () => {
+        assert.strictEqual(
+            parseRemote('https://gitlab.acme.com/o/r.git', { 'gitlab.acme.com': 'unknown-platform' }).platform,
+            'gitlab'
+        );
     });
 
     test('a path with no repo segment is null', () => {
@@ -73,9 +105,12 @@ suite('parseRemote', () => {
 
 suite('buildCommitUrl', () => {
 
-    const github = { host: 'github.com', owner: 'o', repo: 'r' };
-    const gitlab = { host: 'gitlab.com', owner: 'group/sub', repo: 'r' };
-    const bitbucket = { host: 'bitbucket.org', owner: 'o', repo: 'r' };
+    const github    = { host: 'github.com',    owner: 'o',         repo: 'r', platform: 'github' };
+    const gitlab    = { host: 'gitlab.com',    owner: 'group/sub', repo: 'r', platform: 'gitlab' };
+    const bitbucket = { host: 'bitbucket.org', owner: 'o',         repo: 'r', platform: 'bitbucket' };
+    const ghe       = { host: 'git.acme.com',  owner: 'o',         repo: 'r', platform: 'github' };
+    const selfGitlab = { host: 'gitlab.acme.com', owner: 'o',      repo: 'r', platform: 'gitlab' };
+    const gitea     = { host: 'gitea.acme.com', owner: 'o',        repo: 'r', platform: 'gitea' };
 
     test('GitHub blob URL with a line anchor', () => {
         assert.strictEqual(
@@ -95,6 +130,27 @@ suite('buildCommitUrl', () => {
         assert.strictEqual(
             buildCommitUrl(bitbucket, { commitHash: SHA, file: 'src/a.js', line: 12 }),
             `https://bitbucket.org/o/r/src/${SHA}/src/a.js#lines-12`
+        );
+    });
+
+    test('GitHub Enterprise uses the repo host, not github.com', () => {
+        assert.strictEqual(
+            buildCommitUrl(ghe, { commitHash: SHA, file: 'src/a.js', line: 1 }),
+            `https://git.acme.com/o/r/blob/${SHA}/src/a.js#L1`
+        );
+    });
+
+    test('self-hosted GitLab uses the repo host with /-/blob', () => {
+        assert.strictEqual(
+            buildCommitUrl(selfGitlab, { commitHash: SHA, file: 'src/a.js', line: 1 }),
+            `https://gitlab.acme.com/o/r/-/blob/${SHA}/src/a.js#L1`
+        );
+    });
+
+    test('Gitea uses /src/commit/', () => {
+        assert.strictEqual(
+            buildCommitUrl(gitea, { commitHash: SHA, file: 'src/a.js', line: 1 }),
+            `https://gitea.acme.com/o/r/src/commit/${SHA}/src/a.js#L1`
         );
     });
 
@@ -128,8 +184,31 @@ suite('buildCommitUrl', () => {
 
 suite('isPermalinkUrl', () => {
 
-    test('accepts a URL this module built', () => {
+    const customRemote = { host: 'git.acme.com', owner: 'o', repo: 'r', platform: 'github' };
+
+    test('accepts a URL built for a well-known host', () => {
         assert.strictEqual(isPermalinkUrl(`https://github.com/o/r/blob/${SHA}/a.js#L1`), true);
+    });
+
+    test('accepts a URL built for a custom host when remoteInfo matches', () => {
+        assert.strictEqual(
+            isPermalinkUrl(`https://git.acme.com/o/r/blob/${SHA}/a.js#L1`, customRemote),
+            true
+        );
+    });
+
+    test('rejects a custom-host URL without remoteInfo', () => {
+        assert.strictEqual(
+            isPermalinkUrl(`https://git.acme.com/o/r/blob/${SHA}/a.js#L1`),
+            false
+        );
+    });
+
+    test('rejects a custom-host URL when remoteInfo host does not match', () => {
+        assert.strictEqual(
+            isPermalinkUrl(`https://git.evil.com/o/r/blob/${SHA}/a.js#L1`, customRemote),
+            false
+        );
     });
 
     test('rejects a lookalike host', () => {

--- a/test/git-permalink.test.js
+++ b/test/git-permalink.test.js
@@ -66,14 +66,9 @@ suite('parseRemote', () => {
     });
 
     test('customHostTypes is case-insensitive on the hostname key', () => {
-        assert.strictEqual(
+        assert.deepStrictEqual(
             parseRemote('https://git.acme.com/o/r.git', { 'GIT.ACME.COM': 'gitea' }),
-            null // key not matched because we lowercase the parsed host; user must provide lowercase key
-        );
-        // But a lowercase key works:
-        assert.strictEqual(
-            parseRemote('https://git.acme.com/o/r.git', { 'git.acme.com': 'gitea' }).platform,
-            'gitea'
+            { host: 'git.acme.com', owner: 'o', repo: 'r', platform: 'gitea' }
         );
     });
 

--- a/test/open-commit-url.test.js
+++ b/test/open-commit-url.test.js
@@ -17,11 +17,11 @@ function resolveCommitUrl(scanResults, remoteInfo, findingIndex) {
         file: finding.file,
         line: finding.line
     });
-    return url && isPermalinkUrl(url) ? url : null;
+    return url && isPermalinkUrl(url, remoteInfo) ? url : null;
 }
 
 const SHA = 'abc1234567890abcdef1234567890abcdef12345';
-const REMOTE = { host: 'github.com', owner: 'o', repo: 'r' };
+const REMOTE = { host: 'github.com', owner: 'o', repo: 'r', platform: 'github' };
 const RESULTS = [{ commitHash: SHA, file: 'src/a.js', line: 5 }];
 
 suite('openCommitUrl resolution', () => {


### PR DESCRIPTION
…s for any host

- git-rewrite.js: add findWindowsUserScriptsDir() to probe the pip --user scripts directory on Windows (%APPDATA%\Python\PythonXX\Scripts); used as a third fallback in detectFilterRepo() and runGitFilterRepo() so git-filter-repo installed via 'pip install --user' is found even when that directory is not on PATH

- scan-engine-config.js / package.json: raise the default scan timeout from 300 s to 600 s so larger repositories complete without hitting the limit and showing a partial-coverage warning

- git-permalink.js: replace the three-host allowlist with a full rewrite that supports any git remote; platform type (github/gitlab/bitbucket/ gitea) is inferred from the hostname so self-hosted and GitHub Enterprise instances produce correct URLs; new leakLock.git.customHostTypes setting lets users pin a hostname to a specific platform explicitly

- leakLockPanel.js: pass customHostTypes and remoteInfo through the permalink call chain so every parseRemote / isPermalinkUrl call uses the repository's own remote as the source of truth